### PR TITLE
feat: [#28] Add BashStatus tool for async task status polling

### DIFF
--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -1233,6 +1233,7 @@ func builtinToolFactories(root string, sandboxDisabled bool, entry EntryPoint, s
 	factories["web_fetch"] = func() tool.Tool { return toolbuiltin.NewWebFetchTool(nil) }
 	factories["web_search"] = func() tool.Tool { return toolbuiltin.NewWebSearchTool(nil) }
 	factories["bash_output"] = func() tool.Tool { return toolbuiltin.NewBashOutputTool(nil) }
+	factories["bash_status"] = func() tool.Tool { return toolbuiltin.NewBashStatusTool() }
 	factories["kill_task"] = func() tool.Tool { return toolbuiltin.NewKillTaskTool() }
 	factories["todo_write"] = func() tool.Tool { return toolbuiltin.NewTodoWriteTool() }
 	factories["ask_user_question"] = func() tool.Tool { return toolbuiltin.NewAskUserQuestionTool() }
@@ -1255,6 +1256,7 @@ func builtinOrder(entry EntryPoint) []string {
 		"web_fetch",
 		"web_search",
 		"bash_output",
+		"bash_status",
 		"kill_task",
 		"todo_write",
 		"ask_user_question",

--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -211,7 +211,7 @@ func TestRegisterToolsUsesDefaultImplementations(t *testing.T) {
 		t.Fatal("expected task tool to be registered")
 	}
 	tools := registry.List()
-	expected := []string{"Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch", "BashOutput", "KillTask", "TodoWrite", "AskUserQuestion", "Skill", "SlashCommand", "Grep", "Glob", "Task"}
+	expected := []string{"Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch", "BashOutput", "BashStatus", "KillTask", "TodoWrite", "AskUserQuestion", "Skill", "SlashCommand", "Grep", "Glob", "Task"}
 	if len(tools) != len(expected) {
 		t.Fatalf("expected %d default tools, got %d", len(expected), len(tools))
 	}
@@ -362,8 +362,8 @@ func TestRegisterToolsTaskNotAddedForCI(t *testing.T) {
 	if _, ok := seen["Task"]; ok {
 		t.Fatal("Task tool should be absent in CI mode")
 	}
-	if len(seen) != 14 { // all built-ins except Task
-		t.Fatalf("expected 14 built-ins without Task, got %d", len(seen))
+	if len(seen) != 15 { // all built-ins except Task
+		t.Fatalf("expected 15 built-ins without Task, got %d", len(seen))
 	}
 }
 

--- a/pkg/tool/builtin/bash.go
+++ b/pkg/tool/builtin/bash.go
@@ -50,7 +50,7 @@ const (
 	- **Optional**: timeout in milliseconds (max 600000ms/10 min, default 120000ms/2 min)
 	- **Description**: Write clear 5-10 word description of command purpose
 	- **Output limit**: Truncated if exceeds 30000 characters
-	- **Async execution**: Set 'async=true' for long-running tasks (dev servers, log tailing). Use BashOutput with task_id to poll output, and KillTask to stop.
+	- **Async execution**: Set 'async=true' for long-running tasks (dev servers, log tailing). Use BashStatus with task_id to poll status (no output consumption), BashOutput with task_id to poll output, and KillTask to stop.
 
 	## Command Preferences
 

--- a/pkg/tool/builtin/bash_async_helpers_test.go
+++ b/pkg/tool/builtin/bash_async_helpers_test.go
@@ -1,0 +1,78 @@
+package toolbuiltin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAsyncFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		params  map[string]interface{}
+		want    bool
+		wantErr string
+	}{
+		{name: "nil params", params: nil, want: false},
+		{name: "missing async", params: map[string]interface{}{}, want: false},
+		{name: "nil async", params: map[string]interface{}{"async": nil}, want: false},
+		{name: "bool true", params: map[string]interface{}{"async": true}, want: true},
+		{name: "bool false", params: map[string]interface{}{"async": false}, want: false},
+		{name: "string true", params: map[string]interface{}{"async": "true"}, want: true},
+		{name: "string false with spaces", params: map[string]interface{}{"async": " false "}, want: false},
+		{name: "empty string", params: map[string]interface{}{"async": ""}, want: false},
+		{name: "invalid string", params: map[string]interface{}{"async": "nope"}, wantErr: "async must be boolean"},
+		{name: "invalid type", params: map[string]interface{}{"async": 123}, wantErr: "async must be boolean got"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAsyncFlag(tc.params)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestOptionalAsyncTaskID(t *testing.T) {
+	cases := []struct {
+		name    string
+		params  map[string]interface{}
+		want    string
+		wantErr string
+	}{
+		{name: "nil params", params: nil, want: ""},
+		{name: "missing task_id", params: map[string]interface{}{}, want: ""},
+		{name: "nil task_id", params: map[string]interface{}{"task_id": nil}, want: ""},
+		{name: "valid task_id", params: map[string]interface{}{"task_id": "t-1"}, want: "t-1"},
+		{name: "empty task_id", params: map[string]interface{}{"task_id": "   "}, wantErr: "task_id cannot be empty"},
+		{name: "non-string task_id", params: map[string]interface{}{"task_id": 123}, wantErr: "task_id must be string"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := optionalAsyncTaskID(tc.params)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/tool/builtin/bashstatus.go
+++ b/pkg/tool/builtin/bashstatus.go
@@ -1,0 +1,88 @@
+package toolbuiltin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cexll/agentsdk-go/pkg/tool"
+)
+
+const bashStatusDescription = "Check async bash task status without consuming output."
+
+var bashStatusSchema = &tool.JSONSchema{
+	Type: "object",
+	Properties: map[string]interface{}{
+		"task_id": map[string]interface{}{
+			"type":        "string",
+			"description": "Async task ID returned from Bash async mode.",
+		},
+	},
+	Required: []string{"task_id"},
+}
+
+// BashStatusTool checks async task status without consuming buffered output.
+// Returns: {"status":"running|completed|failed", "exit_code":0}
+type BashStatusTool struct{}
+
+func NewBashStatusTool() *BashStatusTool { return &BashStatusTool{} }
+
+func (b *BashStatusTool) Name() string { return "BashStatus" }
+
+func (b *BashStatusTool) Description() string { return bashStatusDescription }
+
+func (b *BashStatusTool) Schema() *tool.JSONSchema { return bashStatusSchema }
+
+func (b *BashStatusTool) Execute(ctx context.Context, params map[string]interface{}) (*tool.ToolResult, error) {
+	if ctx == nil {
+		return nil, errors.New("context is nil")
+	}
+	id, err := parseBashStatusTaskID(params)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	for _, info := range DefaultAsyncTaskManager().List() {
+		if info.ID != id {
+			continue
+		}
+		payload := map[string]interface{}{
+			"task_id": id,
+			"status":  info.Status,
+		}
+		switch info.Status {
+		case "completed":
+			payload["exit_code"] = 0
+		case "failed":
+			payload["error"] = info.Error
+		}
+		out, _ := json.Marshal(payload)
+		return &tool.ToolResult{Success: true, Output: string(out), Data: payload}, nil
+	}
+
+	return nil, fmt.Errorf("task %s not found", id)
+}
+
+func parseBashStatusTaskID(params map[string]interface{}) (string, error) {
+	if params == nil {
+		return "", errors.New("params is nil")
+	}
+	raw, ok := params["task_id"]
+	if !ok {
+		return "", errors.New("task_id is required")
+	}
+	value, err := coerceString(raw)
+	if err != nil {
+		return "", fmt.Errorf("task_id must be string: %w", err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("task_id cannot be empty")
+	}
+	return value, nil
+}

--- a/pkg/tool/builtin/bashstatus_test.go
+++ b/pkg/tool/builtin/bashstatus_test.go
@@ -1,0 +1,204 @@
+package toolbuiltin
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBashStatusRunningTaskReturnsRunning(t *testing.T) {
+	skipIfWindows(t)
+	defaultAsyncTaskManager = newAsyncTaskManager()
+
+	dir := cleanTempDir(t)
+	bash := NewBashToolWithRoot(dir)
+	res, err := bash.Execute(context.Background(), map[string]interface{}{
+		"command": "sleep 2",
+		"async":   true,
+	})
+	if err != nil {
+		t.Fatalf("async bash: %v", err)
+	}
+	id := res.Data.(map[string]interface{})["task_id"].(string)
+
+	statusTool := NewBashStatusTool()
+	got, err := statusTool.Execute(context.Background(), map[string]interface{}{"task_id": id})
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	data := got.Data.(map[string]interface{})
+	if data["status"] != "running" {
+		t.Fatalf("expected status=running, got %+v", data)
+	}
+
+	_ = DefaultAsyncTaskManager().Kill(id)
+	task, _ := DefaultAsyncTaskManager().lookup(id)
+	select {
+	case <-task.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("task did not stop")
+	}
+}
+
+func TestBashStatusCompletedTaskReturnsExitCodeAndDoesNotConsumeOutput(t *testing.T) {
+	skipIfWindows(t)
+	defaultAsyncTaskManager = newAsyncTaskManager()
+
+	dir := cleanTempDir(t)
+	bash := NewBashToolWithRoot(dir)
+	res, err := bash.Execute(context.Background(), map[string]interface{}{
+		"command": "echo hello",
+		"async":   true,
+	})
+	if err != nil {
+		t.Fatalf("async bash: %v", err)
+	}
+	id := res.Data.(map[string]interface{})["task_id"].(string)
+
+	task, _ := DefaultAsyncTaskManager().lookup(id)
+	select {
+	case <-task.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("task did not complete")
+	}
+
+	statusTool := NewBashStatusTool()
+	got, err := statusTool.Execute(context.Background(), map[string]interface{}{"task_id": id})
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	data := got.Data.(map[string]interface{})
+	if data["status"] != "completed" {
+		t.Fatalf("expected status=completed, got %+v", data)
+	}
+	exitCode, ok := data["exit_code"].(int)
+	if !ok || exitCode != 0 {
+		t.Fatalf("expected exit_code=0, got %+v", data["exit_code"])
+	}
+
+	out, done, err := DefaultAsyncTaskManager().GetOutput(id)
+	if err != nil {
+		t.Fatalf("get output: %v", err)
+	}
+	if !done {
+		t.Fatalf("expected done=true")
+	}
+	if !strings.Contains(out, "hello") {
+		t.Fatalf("expected output to contain hello, got %q", out)
+	}
+}
+
+func TestBashStatusFailedTaskReturnsFailedWithError(t *testing.T) {
+	skipIfWindows(t)
+	defaultAsyncTaskManager = newAsyncTaskManager()
+
+	dir := cleanTempDir(t)
+	bash := NewBashToolWithRoot(dir)
+	res, err := bash.Execute(context.Background(), map[string]interface{}{
+		"command": "exit 3",
+		"async":   true,
+	})
+	if err != nil {
+		t.Fatalf("async bash: %v", err)
+	}
+	id := res.Data.(map[string]interface{})["task_id"].(string)
+
+	task, _ := DefaultAsyncTaskManager().lookup(id)
+	select {
+	case <-task.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("task did not complete")
+	}
+
+	statusTool := NewBashStatusTool()
+	got, err := statusTool.Execute(context.Background(), map[string]interface{}{"task_id": id})
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	data := got.Data.(map[string]interface{})
+	if data["status"] != "failed" {
+		t.Fatalf("expected status=failed, got %+v", data)
+	}
+	errMsg, ok := data["error"].(string)
+	if !ok || strings.TrimSpace(errMsg) == "" {
+		t.Fatalf("expected error message, got %+v", data["error"])
+	}
+	if !strings.Contains(errMsg, "exit status") {
+		t.Fatalf("expected error to mention exit status, got %q", errMsg)
+	}
+}
+
+func TestBashStatusUnknownTaskReturnsError(t *testing.T) {
+	defaultAsyncTaskManager = newAsyncTaskManager()
+	statusTool := NewBashStatusTool()
+	if _, err := statusTool.Execute(context.Background(), map[string]interface{}{"task_id": "missing"}); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestBashStatusMetadata(t *testing.T) {
+	statusTool := NewBashStatusTool()
+	if statusTool.Name() != "BashStatus" {
+		t.Fatalf("unexpected name %q", statusTool.Name())
+	}
+	if strings.TrimSpace(statusTool.Description()) == "" {
+		t.Fatalf("expected non-empty description")
+	}
+	schema := statusTool.Schema()
+	if schema == nil || schema.Type != "object" {
+		t.Fatalf("unexpected schema %+v", schema)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "task_id" {
+		t.Fatalf("unexpected required %+v", schema.Required)
+	}
+	raw, ok := schema.Properties["task_id"]
+	if !ok {
+		t.Fatalf("schema missing task_id")
+	}
+	prop := raw.(map[string]interface{})
+	if prop["type"] != "string" {
+		t.Fatalf("unexpected task_id schema %+v", prop)
+	}
+}
+
+func TestBashStatusNilContextHandling(t *testing.T) {
+	statusTool := NewBashStatusTool()
+	if _, err := statusTool.Execute(nil, map[string]interface{}{"task_id": "x"}); err == nil || !strings.Contains(err.Error(), "context is nil") {
+		t.Fatalf("expected context is nil error, got %v", err)
+	}
+}
+
+func TestBashStatusCancelledContextReturnsError(t *testing.T) {
+	statusTool := NewBashStatusTool()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := statusTool.Execute(ctx, map[string]interface{}{"task_id": "x"}); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestBashStatusTaskIDValidation(t *testing.T) {
+	statusTool := NewBashStatusTool()
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		params map[string]interface{}
+		want   string
+	}{
+		{name: "nil params", params: nil, want: "params is nil"},
+		{name: "missing task_id", params: map[string]interface{}{}, want: "task_id is required"},
+		{name: "empty task_id", params: map[string]interface{}{"task_id": ""}, want: "task_id cannot be empty"},
+		{name: "non-string task_id", params: map[string]interface{}{"task_id": 123}, want: "task_id must be string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := statusTool.Execute(ctx, tc.params); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}

--- a/pkg/tool/builtin/killtask_test.go
+++ b/pkg/tool/builtin/killtask_test.go
@@ -2,6 +2,7 @@ package toolbuiltin
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -37,5 +38,70 @@ func TestKillTaskToolErrorsOnMissingTask(t *testing.T) {
 	tool := NewKillTaskTool()
 	if _, err := tool.Execute(context.Background(), map[string]interface{}{"task_id": "missing"}); err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestKillTaskToolMetadata(t *testing.T) {
+	tool := NewKillTaskTool()
+	if tool.Name() != "KillTask" {
+		t.Fatalf("unexpected name %q", tool.Name())
+	}
+	if strings.TrimSpace(tool.Description()) == "" {
+		t.Fatalf("expected non-empty description")
+	}
+	schema := tool.Schema()
+	if schema == nil || schema.Type != "object" {
+		t.Fatalf("unexpected schema %+v", schema)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "task_id" {
+		t.Fatalf("unexpected required %+v", schema.Required)
+	}
+	raw, ok := schema.Properties["task_id"]
+	if !ok {
+		t.Fatalf("schema missing task_id")
+	}
+	prop := raw.(map[string]interface{})
+	if prop["type"] != "string" {
+		t.Fatalf("unexpected task_id schema %+v", prop)
+	}
+}
+
+func TestKillTaskToolNilContextHandling(t *testing.T) {
+	tool := NewKillTaskTool()
+	if _, err := tool.Execute(nil, map[string]interface{}{"task_id": "x"}); err == nil || !strings.Contains(err.Error(), "context is nil") {
+		t.Fatalf("expected context is nil error, got %v", err)
+	}
+}
+
+func TestKillTaskToolCancelledContextReturnsError(t *testing.T) {
+	tool := NewKillTaskTool()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := tool.Execute(ctx, map[string]interface{}{"task_id": "x"}); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestKillTaskToolTaskIDValidation(t *testing.T) {
+	tool := NewKillTaskTool()
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		params map[string]interface{}
+		want   string
+	}{
+		{name: "nil params", params: nil, want: "params is nil"},
+		{name: "missing task_id", params: map[string]interface{}{}, want: "task_id is required"},
+		{name: "empty task_id", params: map[string]interface{}{"task_id": ""}, want: "task_id cannot be empty"},
+		{name: "non-string task_id", params: map[string]interface{}{"task_id": 123}, want: "task_id must be string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tool.Execute(ctx, tc.params); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Implements Option A (polling-based) from issue #28 by adding a new `BashStatus` tool for checking async task status without consuming output.

## Changes

- **New BashStatus tool** (`pkg/tool/builtin/bashstatus.go`):
  - Provides lightweight status checking for async bash tasks
  - Returns `{"status": "running|completed|failed", "exit_code": 0}`
  - Does NOT consume output buffer (unlike BashOutput)
  - Uses `AsyncTaskManager.List()` to get task info

- **Tool registration** (`pkg/api/agent.go`):
  - Added `bash_status` factory to builtin tools
  - Placed in builtin order after `bash_output`

- **Documentation updates** (`pkg/tool/builtin/bash.go`):
  - Updated Bash tool description to reference BashStatus for polling
  - Clarified: BashStatus for status-only, BashOutput for reading output, KillTask for stopping

- **Comprehensive test coverage**:
  - `pkg/tool/builtin/bashstatus_test.go`: Full test suite (running/completed/failed/unknown tasks)
  - `pkg/tool/builtin/bash_async_helpers_test.go`: Helper function tests
  - Updated `pkg/tool/builtin/killtask_test.go` for better coverage
  - Fixed test assertions in `pkg/api/helpers_test.go` for updated builtin count

## Test Results

```bash
✅ go test ./pkg/tool/builtin -run TestBashStatus -v
✅ go test ./pkg/tool/builtin -cover: 90.5% coverage
✅ bashstatus.go Execute: 94.1% coverage
✅ All pkg/api tests pass
```

## Usage Example

```go
// Start async task
bash.Execute(ctx, map[string]interface{}{
    "command": "sleep 5 && echo done",
    "async": true,
})
// Returns: {"task_id": "task-abc123", "status": "running"}

// Check status without consuming output
bashStatus.Execute(ctx, map[string]interface{}{
    "task_id": "task-abc123",
})
// Returns: {"task_id": "task-abc123", "status": "running"}

// Later: Read output (consumes buffer)
bashOutput.Execute(ctx, map[string]interface{}{
    "task_id": "task-abc123",
})
// Returns: {"task_id": "task-abc123", "status": "completed", "output": "done"}
```

Closes #28