### PR TITLE
fix: copy Result field in convertToolCalls

### DIFF
--- a/pkg/api/runtime_helpers.go
+++ b/pkg/api/runtime_helpers.go
@@ -90,7 +90,12 @@ func convertToolCalls(calls []message.ToolCall) []model.ToolCall {
 	}
 	out := make([]model.ToolCall, len(calls))
 	for i, call := range calls {
-		out[i] = model.ToolCall{ID: call.ID, Name: call.Name, Arguments: cloneArguments(call.Arguments)}
+		out[i] = model.ToolCall{
+			ID:        call.ID,
+			Name:      call.Name,
+			Arguments: cloneArguments(call.Arguments),
+			Result:    call.Result,
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
Fixes #36

The `convertToolCalls` function was not copying the `Result` field from `message.ToolCall` to `model.ToolCall`, causing tool execution results to be lost before being sent to the LLM.

## Changes
- Added `Result: call.Result` to the `model.ToolCall` initialization in `convertToolCalls`

## Impact
Before this fix, the LLM would claim "no output" despite tools returning valid data, because:
1. `runtimeToolExecutor.Execute` correctly sets `message.ToolCall.Result = content`
2. `convertMessages` calls `convertToolCalls` which **loses Result**
3. `anthropic.go:buildToolResults` finds `call.Result` is empty
4. Final tool result sent to LLM is empty string

## Test Plan
- [x] Existing tests pass (`go test ./pkg/api/... -run TestConvert`)
- [x] Verified fix addresses the root cause in issue #36

Generated with SWE-Agent.ai

Co-Authored-By: SWE-Agent.ai <noreply@swe-agent.ai>