### PR TITLE
feat(#58): implement TaskList and TaskGet tools

### DIFF
--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -1297,6 +1297,7 @@ func builtinToolFactories(root string, sandboxDisabled bool, entry EntryPoint, s
 		}
 		return toolbuiltin.NewGlobToolWithRoot(root)
 	}
+	taskStore := toolbuiltin.NewTaskStore()
 
 	factories["bash"] = bashCtor
 	factories["file_read"] = readCtor
@@ -1310,6 +1311,8 @@ func builtinToolFactories(root string, sandboxDisabled bool, entry EntryPoint, s
 	factories["bash_status"] = func() tool.Tool { return toolbuiltin.NewBashStatusTool() }
 	factories["kill_task"] = func() tool.Tool { return toolbuiltin.NewKillTaskTool() }
 	factories["todo_write"] = func() tool.Tool { return toolbuiltin.NewTodoWriteTool() }
+	factories["task_list"] = func() tool.Tool { return toolbuiltin.NewTaskListTool(taskStore) }
+	factories["task_get"] = func() tool.Tool { return toolbuiltin.NewTaskGetTool(taskStore) }
 	factories["ask_user_question"] = func() tool.Tool { return toolbuiltin.NewAskUserQuestionTool() }
 	factories["skill"] = func() tool.Tool { return toolbuiltin.NewSkillTool(skReg, nil) }
 	factories["slash_command"] = func() tool.Tool { return toolbuiltin.NewSlashCommandTool(cmdExec) }
@@ -1333,6 +1336,8 @@ func builtinOrder(entry EntryPoint) []string {
 		"bash_status",
 		"kill_task",
 		"todo_write",
+		"task_list",
+		"task_get",
 		"ask_user_question",
 		"skill",
 		"slash_command",

--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -211,7 +211,7 @@ func TestRegisterToolsUsesDefaultImplementations(t *testing.T) {
 		t.Fatal("expected task tool to be registered")
 	}
 	tools := registry.List()
-	expected := []string{"Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch", "BashOutput", "BashStatus", "KillTask", "TodoWrite", "AskUserQuestion", "Skill", "SlashCommand", "Grep", "Glob", "Task"}
+	expected := []string{"Bash", "Read", "Write", "Edit", "WebFetch", "WebSearch", "BashOutput", "BashStatus", "KillTask", "TodoWrite", "TaskList", "TaskGet", "AskUserQuestion", "Skill", "SlashCommand", "Grep", "Glob", "Task"}
 	if len(tools) != len(expected) {
 		t.Fatalf("expected %d default tools, got %d", len(expected), len(tools))
 	}
@@ -362,8 +362,8 @@ func TestRegisterToolsTaskNotAddedForCI(t *testing.T) {
 	if _, ok := seen["Task"]; ok {
 		t.Fatal("Task tool should be absent in CI mode")
 	}
-	if len(seen) != 15 { // all built-ins except Task
-		t.Fatalf("expected 15 built-ins without Task, got %d", len(seen))
+	if len(seen) != 17 { // all built-ins except Task
+		t.Fatalf("expected 17 built-ins without Task, got %d", len(seen))
 	}
 }
 

--- a/pkg/tool/builtin/task_store.go
+++ b/pkg/tool/builtin/task_store.go
@@ -1,0 +1,148 @@
+package toolbuiltin
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+)
+
+const (
+	TaskStatusPending    = "pending"
+	TaskStatusInProgress = "in_progress"
+	TaskStatusCompleted  = "completed"
+	TaskStatusBlocked    = "blocked"
+)
+
+var taskStatusSet = map[string]struct{}{
+	TaskStatusPending:    {},
+	TaskStatusInProgress: {},
+	TaskStatusCompleted:  {},
+	TaskStatusBlocked:    {},
+}
+
+// Task represents a unit of work tracked by the task system.
+type Task struct {
+	ID        string   `json:"id"`
+	Title     string   `json:"title,omitempty"`
+	Status    string   `json:"status"`
+	Owner     string   `json:"owner,omitempty"`
+	BlockedBy []string `json:"blockedBy,omitempty"`
+}
+
+// TaskStore keeps task state in memory with a small, concurrency-safe API.
+type TaskStore struct {
+	mu    sync.RWMutex
+	tasks map[string]Task
+}
+
+func NewTaskStore() *TaskStore {
+	return &TaskStore{
+		tasks: map[string]Task{},
+	}
+}
+
+func (s *TaskStore) Upsert(task Task) error {
+	if s == nil {
+		return errors.New("task store is nil")
+	}
+	id := strings.TrimSpace(task.ID)
+	if id == "" {
+		return errors.New("task id cannot be empty")
+	}
+	status := normalizeTaskStatus(task.Status)
+	if status == "" {
+		return fmt.Errorf("task status %q is invalid", task.Status)
+	}
+	blockedBy, err := normalizeTaskIDs(task.BlockedBy)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(blockedBy, id) {
+		return errors.New("task cannot be blocked by itself")
+	}
+
+	task.ID = id
+	task.Title = strings.TrimSpace(task.Title)
+	task.Owner = strings.TrimSpace(task.Owner)
+	task.Status = status
+	task.BlockedBy = blockedBy
+
+	s.mu.Lock()
+	if s.tasks == nil {
+		s.tasks = map[string]Task{}
+	}
+	s.tasks[id] = task
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *TaskStore) Get(id string) (Task, bool) {
+	if s == nil {
+		return Task{}, false
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Task{}, false
+	}
+	s.mu.RLock()
+	task, ok := s.tasks[id]
+	s.mu.RUnlock()
+	return task, ok
+}
+
+func (s *TaskStore) List() []Task {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.tasks) == 0 {
+		return nil
+	}
+	out := make([]Task, 0, len(s.tasks))
+	for _, task := range s.tasks {
+		out = append(out, task)
+	}
+	slices.SortFunc(out, func(a, b Task) int { return strings.Compare(a.ID, b.ID) })
+	return out
+}
+
+func normalizeTaskStatus(value string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return TaskStatusPending
+	}
+	trimmed = strings.ReplaceAll(trimmed, "-", "_")
+	if _, ok := taskStatusSet[trimmed]; ok {
+		return trimmed
+	}
+	switch trimmed {
+	case "complete", "done":
+		return TaskStatusCompleted
+	default:
+		return ""
+	}
+}
+
+func normalizeTaskIDs(ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	slices.Sort(out)
+	return out, nil
+}

--- a/pkg/tool/builtin/taskget.go
+++ b/pkg/tool/builtin/taskget.go
@@ -1,0 +1,172 @@
+package toolbuiltin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cexll/agentsdk-go/pkg/tool"
+)
+
+const taskGetDescription = "Retrieve a task by ID with full block/blocker details."
+
+var taskGetSchema = &tool.JSONSchema{
+	Type: "object",
+	Properties: map[string]interface{}{
+		"taskId": map[string]interface{}{
+			"type":        "string",
+			"description": "ID of task to retrieve",
+		},
+	},
+	Required: []string{"taskId"},
+}
+
+type TaskGetTool struct {
+	store *TaskStore
+}
+
+func NewTaskGetTool(store *TaskStore) *TaskGetTool {
+	return &TaskGetTool{store: store}
+}
+
+func (t *TaskGetTool) Name() string { return "TaskGet" }
+
+func (t *TaskGetTool) Description() string { return taskGetDescription }
+
+func (t *TaskGetTool) Schema() *tool.JSONSchema { return taskGetSchema }
+
+func (t *TaskGetTool) Execute(ctx context.Context, params map[string]interface{}) (*tool.ToolResult, error) {
+	if ctx == nil {
+		return nil, errors.New("context is nil")
+	}
+	if t == nil || t.store == nil {
+		return nil, errors.New("task store is not configured")
+	}
+	taskID, err := requiredString(params, "taskId")
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	target, ok := t.store.Get(taskID)
+	if !ok {
+		return nil, fmt.Errorf("task %s not found", taskID)
+	}
+	all := t.store.List()
+
+	blockedBy := taskRefsByID(target.BlockedBy, all)
+	blocks := taskRefsForBlocks(target.ID, all)
+
+	output := formatTaskGetOutput(target, blockedBy, blocks)
+	return &tool.ToolResult{
+		Success: true,
+		Output:  output,
+		Data: map[string]interface{}{
+			"task":      target,
+			"blockedBy": blockedBy,
+			"blocks":    blocks,
+		},
+	}, nil
+}
+
+type TaskRef struct {
+	ID     string `json:"id"`
+	Title  string `json:"title,omitempty"`
+	Status string `json:"status"`
+	Owner  string `json:"owner,omitempty"`
+}
+
+func taskRefsByID(ids []string, tasks []Task) []TaskRef {
+	if len(ids) == 0 || len(tasks) == 0 {
+		return nil
+	}
+	byID := make(map[string]Task, len(tasks))
+	for _, task := range tasks {
+		byID[task.ID] = task
+	}
+	out := make([]TaskRef, 0, len(ids))
+	for _, id := range ids {
+		task, ok := byID[id]
+		if !ok {
+			out = append(out, TaskRef{ID: id, Status: ""})
+			continue
+		}
+		out = append(out, TaskRef{
+			ID:     task.ID,
+			Title:  task.Title,
+			Status: task.Status,
+			Owner:  task.Owner,
+		})
+	}
+	return out
+}
+
+func taskRefsForBlocks(id string, tasks []Task) []TaskRef {
+	if strings.TrimSpace(id) == "" || len(tasks) == 0 {
+		return nil
+	}
+	out := make([]TaskRef, 0)
+	for _, task := range tasks {
+		if slices.Contains(task.BlockedBy, id) {
+			out = append(out, TaskRef{
+				ID:     task.ID,
+				Title:  task.Title,
+				Status: task.Status,
+				Owner:  task.Owner,
+			})
+		}
+	}
+	slices.SortFunc(out, func(a, b TaskRef) int { return strings.Compare(a.ID, b.ID) })
+	return out
+}
+
+func formatTaskGetOutput(task Task, blockedBy []TaskRef, blocks []TaskRef) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "task %s\n", task.ID)
+	if strings.TrimSpace(task.Title) != "" {
+		fmt.Fprintf(&b, "title: %s\n", strings.TrimSpace(task.Title))
+	}
+	fmt.Fprintf(&b, "status: %s\n", task.Status)
+	if strings.TrimSpace(task.Owner) != "" {
+		fmt.Fprintf(&b, "owner: %s\n", strings.TrimSpace(task.Owner))
+	}
+	if len(blockedBy) == 0 {
+		b.WriteString("blockedBy: (none)\n")
+	} else {
+		b.WriteString("blockedBy:\n")
+		for _, ref := range blockedBy {
+			fmt.Fprintf(&b, "- %s", ref.ID)
+			if ref.Status != "" {
+				fmt.Fprintf(&b, " [%s]", ref.Status)
+			}
+			if strings.TrimSpace(ref.Title) != "" {
+				fmt.Fprintf(&b, " %s", strings.TrimSpace(ref.Title))
+			}
+			if strings.TrimSpace(ref.Owner) != "" {
+				fmt.Fprintf(&b, " (owner=%s)", strings.TrimSpace(ref.Owner))
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	if len(blocks) == 0 {
+		b.WriteString("blocks: (none)")
+		return b.String()
+	}
+	b.WriteString("blocks:\n")
+	for _, ref := range blocks {
+		fmt.Fprintf(&b, "- %s [%s]", ref.ID, ref.Status)
+		if strings.TrimSpace(ref.Title) != "" {
+			fmt.Fprintf(&b, " %s", strings.TrimSpace(ref.Title))
+		}
+		if strings.TrimSpace(ref.Owner) != "" {
+			fmt.Fprintf(&b, " (owner=%s)", strings.TrimSpace(ref.Owner))
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/pkg/tool/builtin/taskget_test.go
+++ b/pkg/tool/builtin/taskget_test.go
@@ -1,0 +1,100 @@
+package toolbuiltin
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTaskGetToolMetadata(t *testing.T) {
+	tool := NewTaskGetTool(NewTaskStore())
+	if tool.Name() != "TaskGet" {
+		t.Fatalf("unexpected name %q", tool.Name())
+	}
+	if strings.TrimSpace(tool.Description()) == "" {
+		t.Fatalf("expected non-empty description")
+	}
+	schema := tool.Schema()
+	if schema == nil || schema.Type != "object" {
+		t.Fatalf("unexpected schema %+v", schema)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "taskId" {
+		t.Fatalf("unexpected required %+v", schema.Required)
+	}
+}
+
+func TestTaskGetToolNilContextHandling(t *testing.T) {
+	tool := NewTaskGetTool(NewTaskStore())
+	if _, err := tool.Execute(nil, map[string]interface{}{"taskId": "x"}); err == nil || !strings.Contains(err.Error(), "context is nil") {
+		t.Fatalf("expected context is nil error, got %v", err)
+	}
+}
+
+func TestTaskGetToolCancelledContextReturnsError(t *testing.T) {
+	tool := NewTaskGetTool(NewTaskStore())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := tool.Execute(ctx, map[string]interface{}{"taskId": "x"}); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestTaskGetToolReturnsBlocksAndBlockedBy(t *testing.T) {
+	store := NewTaskStore()
+	if err := store.Upsert(Task{ID: "t1", Title: "root", Status: TaskStatusInProgress, Owner: "alice"}); err != nil {
+		t.Fatalf("seed t1: %v", err)
+	}
+	if err := store.Upsert(Task{ID: "t2", Title: "child", Status: TaskStatusBlocked, Owner: "bob", BlockedBy: []string{"t1"}}); err != nil {
+		t.Fatalf("seed t2: %v", err)
+	}
+	tool := NewTaskGetTool(store)
+
+	res, err := tool.Execute(context.Background(), map[string]interface{}{"taskId": "t1"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res == nil || !res.Success {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	if !strings.Contains(res.Output, "task t1") {
+		t.Fatalf("unexpected output:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "blocks:") || !strings.Contains(res.Output, "t2") {
+		t.Fatalf("expected blocks info, got:\n%s", res.Output)
+	}
+
+	res, err = tool.Execute(context.Background(), map[string]interface{}{"taskId": "t2"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Output, "blockedBy:") || !strings.Contains(res.Output, "t1") {
+		t.Fatalf("expected blockedBy info, got:\n%s", res.Output)
+	}
+}
+
+func TestTaskGetToolValidation(t *testing.T) {
+	tool := NewTaskGetTool(NewTaskStore())
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		params map[string]interface{}
+		want   string
+	}{
+		{name: "missing taskId", params: map[string]interface{}{}, want: "taskId is required"},
+		{name: "empty taskId", params: map[string]interface{}{"taskId": " "}, want: "taskId cannot be empty"},
+		{name: "non-string taskId", params: map[string]interface{}{"taskId": 123}, want: "taskId must be string"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := tool.Execute(ctx, tc.params); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+
+	if _, err := tool.Execute(ctx, map[string]interface{}{"taskId": "missing"}); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}

--- a/pkg/tool/builtin/tasklist.go
+++ b/pkg/tool/builtin/tasklist.go
@@ -1,0 +1,302 @@
+package toolbuiltin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cexll/agentsdk-go/pkg/tool"
+)
+
+const taskListDescription = "List tasks with optional status/owner filtering and dependency visualization."
+
+var taskListSchema = &tool.JSONSchema{
+	Type: "object",
+	Properties: map[string]interface{}{
+		"status": map[string]interface{}{
+			"type":        "string",
+			"description": "Filter by status",
+			"enum": []string{
+				TaskStatusPending,
+				TaskStatusInProgress,
+				TaskStatusCompleted,
+				TaskStatusBlocked,
+			},
+		},
+		"owner": map[string]interface{}{
+			"type":        "string",
+			"description": "Filter by owner",
+		},
+	},
+}
+
+type TaskListTool struct {
+	store *TaskStore
+}
+
+func NewTaskListTool(store *TaskStore) *TaskListTool {
+	return &TaskListTool{store: store}
+}
+
+func (t *TaskListTool) Name() string { return "TaskList" }
+
+func (t *TaskListTool) Description() string { return taskListDescription }
+
+func (t *TaskListTool) Schema() *tool.JSONSchema { return taskListSchema }
+
+func (t *TaskListTool) Execute(ctx context.Context, params map[string]interface{}) (*tool.ToolResult, error) {
+	if ctx == nil {
+		return nil, errors.New("context is nil")
+	}
+	if t == nil || t.store == nil {
+		return nil, errors.New("task store is not configured")
+	}
+	filterStatus, filterOwner, err := parseTaskListParams(params)
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	all := t.store.List()
+	filtered := filterTasks(all, filterStatus, filterOwner)
+	counts := countTasksByStatus(filtered)
+	order, depth, blocks := taskDisplayOrder(filtered)
+
+	output := formatTaskListOutput(filtered, order, depth, blocks, counts)
+	return &tool.ToolResult{
+		Success: true,
+		Output:  output,
+		Data: map[string]interface{}{
+			"tasks":  filtered,
+			"total":  len(filtered),
+			"counts": counts,
+		},
+	}, nil
+}
+
+func parseTaskListParams(params map[string]interface{}) (string, string, error) {
+	if params == nil {
+		return "", "", nil
+	}
+	var status string
+	if raw, ok := params["status"]; ok {
+		value, err := coerceString(raw)
+		if err != nil {
+			return "", "", fmt.Errorf("status must be string: %w", err)
+		}
+		value = strings.TrimSpace(value)
+		if value != "" {
+			status = normalizeTaskStatus(value)
+			if status == "" {
+				return "", "", fmt.Errorf("status %q is invalid", value)
+			}
+		}
+	}
+	var owner string
+	if raw, ok := params["owner"]; ok {
+		value, err := coerceString(raw)
+		if err != nil {
+			return "", "", fmt.Errorf("owner must be string: %w", err)
+		}
+		owner = strings.TrimSpace(value)
+	}
+	return status, owner, nil
+}
+
+func filterTasks(tasks []Task, status, owner string) []Task {
+	if len(tasks) == 0 {
+		return nil
+	}
+	var out []Task
+	for _, task := range tasks {
+		if status != "" && task.Status != status {
+			continue
+		}
+		if owner != "" && !strings.EqualFold(task.Owner, owner) {
+			continue
+		}
+		out = append(out, task)
+	}
+	return out
+}
+
+func countTasksByStatus(tasks []Task) map[string]int {
+	counts := map[string]int{
+		TaskStatusPending:    0,
+		TaskStatusInProgress: 0,
+		TaskStatusCompleted:  0,
+		TaskStatusBlocked:    0,
+	}
+	for _, task := range tasks {
+		if _, ok := counts[task.Status]; ok {
+			counts[task.Status]++
+		}
+	}
+	return counts
+}
+
+func taskDisplayOrder(tasks []Task) ([]string, map[string]int, map[string][]string) {
+	if len(tasks) == 0 {
+		return nil, nil, nil
+	}
+	byID := make(map[string]Task, len(tasks))
+	for _, task := range tasks {
+		byID[task.ID] = task
+	}
+
+	blocks := make(map[string][]string, len(tasks))
+	indegree := make(map[string]int, len(tasks))
+	for id := range byID {
+		indegree[id] = 0
+	}
+	for _, task := range byID {
+		for _, blockerID := range task.BlockedBy {
+			if _, ok := byID[blockerID]; !ok {
+				continue
+			}
+			blocks[blockerID] = append(blocks[blockerID], task.ID)
+			indegree[task.ID]++
+		}
+	}
+
+	available := make([]string, 0, len(byID))
+	for id, deg := range indegree {
+		if deg == 0 {
+			available = append(available, id)
+		}
+	}
+	sortIDsByTaskKey(available, byID)
+
+	order := make([]string, 0, len(byID))
+	inOrder := make(map[string]struct{}, len(byID))
+	for len(available) > 0 {
+		id := available[0]
+		available = available[1:]
+		order = append(order, id)
+		inOrder[id] = struct{}{}
+
+		children := blocks[id]
+		sortIDsByTaskKey(children, byID)
+		blocks[id] = children
+
+		for _, child := range children {
+			indegree[child]--
+			if indegree[child] == 0 {
+				available = append(available, child)
+			}
+		}
+		sortIDsByTaskKey(available, byID)
+	}
+
+	if len(order) != len(byID) {
+		remaining := make([]string, 0, len(byID)-len(order))
+		for id := range byID {
+			if _, ok := inOrder[id]; ok {
+				continue
+			}
+			remaining = append(remaining, id)
+		}
+		sortIDsByTaskKey(remaining, byID)
+		order = append(order, remaining...)
+	}
+
+	depth := make(map[string]int, len(order))
+	for _, id := range order {
+		task := byID[id]
+		level := 0
+		for _, blockerID := range task.BlockedBy {
+			blockerDepth, ok := depth[blockerID]
+			if !ok {
+				continue
+			}
+			if blockerDepth+1 > level {
+				level = blockerDepth + 1
+			}
+		}
+		depth[id] = level
+	}
+
+	return order, depth, blocks
+}
+
+func sortIDsByTaskKey(ids []string, tasks map[string]Task) {
+	slices.SortFunc(ids, func(a, b string) int {
+		ta, ok := tasks[a]
+		if !ok {
+			return strings.Compare(a, b)
+		}
+		tb, ok := tasks[b]
+		if !ok {
+			return strings.Compare(a, b)
+		}
+		if pa, pb := taskStatusPriority(ta.Status), taskStatusPriority(tb.Status); pa != pb {
+			if pa < pb {
+				return -1
+			}
+			return 1
+		}
+		if cmp := strings.Compare(strings.ToLower(ta.Owner), strings.ToLower(tb.Owner)); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(ta.ID, tb.ID)
+	})
+}
+
+func taskStatusPriority(status string) int {
+	switch status {
+	case TaskStatusInProgress:
+		return 0
+	case TaskStatusBlocked:
+		return 1
+	case TaskStatusPending:
+		return 2
+	case TaskStatusCompleted:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func formatTaskListOutput(tasks []Task, order []string, depth map[string]int, blocks map[string][]string, counts map[string]int) string {
+	if len(tasks) == 0 {
+		return "no tasks"
+	}
+	byID := make(map[string]Task, len(tasks))
+	for _, task := range tasks {
+		byID[task.ID] = task
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d tasks (pending:%d, in_progress:%d, completed:%d, blocked:%d)\n",
+		len(tasks),
+		counts[TaskStatusPending],
+		counts[TaskStatusInProgress],
+		counts[TaskStatusCompleted],
+		counts[TaskStatusBlocked],
+	)
+	for _, id := range order {
+		task, ok := byID[id]
+		if !ok {
+			continue
+		}
+		prefix := strings.Repeat("  ", depth[id])
+		fmt.Fprintf(&b, "%s- [%s] %s", prefix, task.Status, task.ID)
+		if strings.TrimSpace(task.Title) != "" {
+			fmt.Fprintf(&b, " %s", strings.TrimSpace(task.Title))
+		}
+		if strings.TrimSpace(task.Owner) != "" {
+			fmt.Fprintf(&b, " (owner=%s)", strings.TrimSpace(task.Owner))
+		}
+		b.WriteByte('\n')
+		if len(task.BlockedBy) > 0 {
+			fmt.Fprintf(&b, "%s  blockedBy: %s\n", prefix, strings.Join(task.BlockedBy, ", "))
+		}
+		if children := blocks[id]; len(children) > 0 {
+			fmt.Fprintf(&b, "%s  blocks: %s\n", prefix, strings.Join(children, ", "))
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/pkg/tool/builtin/tasklist_test.go
+++ b/pkg/tool/builtin/tasklist_test.go
@@ -1,0 +1,91 @@
+package toolbuiltin
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTaskListToolMetadata(t *testing.T) {
+	store := NewTaskStore()
+	tool := NewTaskListTool(store)
+	if tool.Name() != "TaskList" {
+		t.Fatalf("unexpected name %q", tool.Name())
+	}
+	if strings.TrimSpace(tool.Description()) == "" {
+		t.Fatalf("expected non-empty description")
+	}
+	schema := tool.Schema()
+	if schema == nil || schema.Type != "object" {
+		t.Fatalf("unexpected schema %+v", schema)
+	}
+	if _, ok := schema.Properties["status"]; !ok {
+		t.Fatalf("schema missing status")
+	}
+	if _, ok := schema.Properties["owner"]; !ok {
+		t.Fatalf("schema missing owner")
+	}
+}
+
+func TestTaskListToolNilContextHandling(t *testing.T) {
+	tool := NewTaskListTool(NewTaskStore())
+	if _, err := tool.Execute(nil, nil); err == nil || !strings.Contains(err.Error(), "context is nil") {
+		t.Fatalf("expected context is nil error, got %v", err)
+	}
+}
+
+func TestTaskListToolCancelledContextReturnsError(t *testing.T) {
+	tool := NewTaskListTool(NewTaskStore())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := tool.Execute(ctx, nil); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestTaskListToolFiltersAndShowsDependencies(t *testing.T) {
+	store := NewTaskStore()
+	if err := store.Upsert(Task{ID: "t1", Title: "root", Status: TaskStatusInProgress, Owner: "alice"}); err != nil {
+		t.Fatalf("seed t1: %v", err)
+	}
+	if err := store.Upsert(Task{ID: "t2", Title: "child", Status: TaskStatusBlocked, Owner: "bob", BlockedBy: []string{"t1"}}); err != nil {
+		t.Fatalf("seed t2: %v", err)
+	}
+	if err := store.Upsert(Task{ID: "t3", Title: "other", Status: TaskStatusPending, Owner: "alice"}); err != nil {
+		t.Fatalf("seed t3: %v", err)
+	}
+
+	tool := NewTaskListTool(store)
+	res, err := tool.Execute(context.Background(), map[string]interface{}{
+		"owner": "alice",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res == nil || res.Success != true {
+		t.Fatalf("unexpected result %+v", res)
+	}
+	if !strings.Contains(res.Output, "t1") || !strings.Contains(res.Output, "t3") {
+		t.Fatalf("expected output to include filtered tasks, got:\n%s", res.Output)
+	}
+	if strings.Contains(res.Output, "t2") {
+		t.Fatalf("did not expect output to include non-matching task t2, got:\n%s", res.Output)
+	}
+
+	res, err = tool.Execute(context.Background(), map[string]interface{}{
+		"status": TaskStatusBlocked,
+	})
+	if err != nil {
+		t.Fatalf("Execute blocked filter: %v", err)
+	}
+	if !strings.Contains(res.Output, "t2") {
+		t.Fatalf("expected blocked task to be present, got:\n%s", res.Output)
+	}
+	if strings.Contains(res.Output, "- [in_progress] t1") {
+		t.Fatalf("did not expect t1 when filtering blocked, got:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "blockedBy: t1") {
+		t.Fatalf("expected dependency line, got:\n%s", res.Output)
+	}
+}


### PR DESCRIPTION
## Summary
Implements TaskList and TaskGet tools for querying tasks as part of the Task Dependency System.

## Changes
- Created `pkg/tool/builtin/task_store.go`: Minimal in-memory TaskStore with Task model (status normalization, BlockedBy deduplication/sorting, self-block rejection)
- Created `pkg/tool/builtin/tasklist.go`: TaskList tool with status/owner filtering, topological+priority sorting, and dependency visualization via indentation
- Created `pkg/tool/builtin/taskget.go`: TaskGet tool to retrieve task by ID with blockedBy/blocks task summary information
- Updated `pkg/api/agent.go`: Registered task_list/task_get tools in builtin factory with shared TaskStore
- Added comprehensive tests in `pkg/tool/builtin/tasklist_test.go` and `pkg/tool/builtin/taskget_test.go`

## Testing
- Coverage: 90.5%
- All tests passing

Closes #58