### PR TITLE
feat(mcp): add tool filters, per-tool timeouts, and review fixes

### DIFF
--- a/docs/custom-tools-guide.md
+++ b/docs/custom-tools-guide.md
@@ -99,5 +99,5 @@ func (t *EchoTool) Execute(ctx context.Context, params map[string]any) (*tool.To
 
 - Name matching is case-insensitive; `-` or spaces are treated as `_`. Prefer the listed lowercase underscore forms.
 - Task tool auto-attaches only in CLI/Platform entrypoints; CI entrypoint skips it.
-- MCP tool registration is independent of these options and always registers all MCP tools.
+- MCP tools are registered by default; when MCP server config includes `enabledTools`/`disabledTools`, registration is filtered accordingly.
 - When names collide, the first tool wins and a warning is logged to highlight the conflict.

--- a/pkg/api/mcp_bridge.go
+++ b/pkg/api/mcp_bridge.go
@@ -8,12 +8,15 @@ import (
 )
 
 type mcpServer struct {
-	Name           string
-	Spec           string
-	URL            string
-	Headers        map[string]string
-	Env            map[string]string
-	TimeoutSeconds int
+	Name               string
+	Spec               string
+	URL                string
+	Headers            map[string]string
+	Env                map[string]string
+	TimeoutSeconds     int
+	EnabledTools       []string
+	DisabledTools      []string
+	ToolTimeoutSeconds int
 }
 
 // collectMCPServers merges explicit API inputs, settings.json entries, and
@@ -60,12 +63,15 @@ func collectMCPServers(settings *config.Settings, explicit []string) []mcpServer
 				}
 			}
 			add(mcpServer{
-				Name:           name,
-				Spec:           spec,
-				URL:            cfg.URL,
-				Headers:        cfg.Headers,
-				Env:            cfg.Env,
-				TimeoutSeconds: cfg.TimeoutSeconds,
+				Name:               name,
+				Spec:               spec,
+				URL:                cfg.URL,
+				Headers:            cfg.Headers,
+				Env:                cfg.Env,
+				TimeoutSeconds:     cfg.TimeoutSeconds,
+				EnabledTools:       cfg.EnabledTools,
+				DisabledTools:      cfg.DisabledTools,
+				ToolTimeoutSeconds: cfg.ToolTimeoutSeconds,
 			})
 		}
 	}

--- a/pkg/api/mcp_bridge_test.go
+++ b/pkg/api/mcp_bridge_test.go
@@ -33,11 +33,14 @@ func TestCollectMCPServersPreservesSettingsOptions(t *testing.T) {
 		MCP: &config.MCPConfig{
 			Servers: map[string]config.MCPServerConfig{
 				"api": {
-					Type:           "http",
-					URL:            "http://settings.example",
-					Headers:        map[string]string{"Authorization": "Bearer x"},
-					Env:            map[string]string{"K": "V"},
-					TimeoutSeconds: 7,
+					Type:               "http",
+					URL:                "http://settings.example",
+					Headers:            map[string]string{"Authorization": "Bearer x"},
+					Env:                map[string]string{"K": "V"},
+					TimeoutSeconds:     7,
+					EnabledTools:       []string{"echo"},
+					DisabledTools:      []string{"sum"},
+					ToolTimeoutSeconds: 9,
 				},
 			},
 		},
@@ -57,6 +60,15 @@ func TestCollectMCPServersPreservesSettingsOptions(t *testing.T) {
 	}
 	if servers[0].Env["K"] != "V" {
 		t.Fatalf("expected env propagated, got %+v", servers[0].Env)
+	}
+	if len(servers[0].EnabledTools) != 1 || servers[0].EnabledTools[0] != "echo" {
+		t.Fatalf("expected enabled tools propagated, got %+v", servers[0].EnabledTools)
+	}
+	if len(servers[0].DisabledTools) != 1 || servers[0].DisabledTools[0] != "sum" {
+		t.Fatalf("expected disabled tools propagated, got %+v", servers[0].DisabledTools)
+	}
+	if servers[0].ToolTimeoutSeconds != 9 {
+		t.Fatalf("expected toolTimeoutSeconds=9, got %d", servers[0].ToolTimeoutSeconds)
 	}
 }
 

--- a/pkg/api/mcp_integration_test.go
+++ b/pkg/api/mcp_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 	_ "unsafe"
 
 	"github.com/cexll/agentsdk-go/pkg/mcp"
@@ -13,6 +14,9 @@ import (
 //go:linkname patchedNewMCPClient github.com/cexll/agentsdk-go/pkg/tool.newMCPClient
 var patchedNewMCPClient func(ctx context.Context, spec string, handler func(context.Context, *mcp.ClientSession)) (*mcp.ClientSession, error)
 
+//go:linkname patchedNewMCPClientWithOptions github.com/cexll/agentsdk-go/pkg/tool.newMCPClientWithOptions
+var patchedNewMCPClientWithOptions func(ctx context.Context, spec string, opts tool.MCPServerOptions, handler func(context.Context, *mcp.ClientSession)) (*mcp.ClientSession, error)
+
 type mcpCallCounter struct {
 	calls int
 	err   error
@@ -20,6 +24,18 @@ type mcpCallCounter struct {
 
 func (c *mcpCallCounter) dial(ctx context.Context, spec string, _ func(context.Context, *mcp.ClientSession)) (*mcp.ClientSession, error) {
 	c.calls++
+	return nil, c.err
+}
+
+type mcpCallCounterWithOptions struct {
+	calls   int
+	err     error
+	lastOps tool.MCPServerOptions
+}
+
+func (c *mcpCallCounterWithOptions) dial(ctx context.Context, spec string, opts tool.MCPServerOptions, _ func(context.Context, *mcp.ClientSession)) (*mcp.ClientSession, error) {
+	c.calls++
+	c.lastOps = opts
 	return nil, c.err
 }
 
@@ -41,5 +57,45 @@ func TestRegisterMCPServersNotBlockedByBuiltinWhitelist(t *testing.T) {
 	}
 	if counter.calls != 1 {
 		t.Fatalf("expected MCP dial invoked once, got %d", counter.calls)
+	}
+}
+
+func TestRegisterMCPServersWithToolOptionsUsesOptionsDialer(t *testing.T) {
+	origBase := patchedNewMCPClient
+	origOpts := patchedNewMCPClientWithOptions
+	baseCounter := &mcpCallCounter{err: errors.New("base dial should not be called")}
+	optCounter := &mcpCallCounterWithOptions{err: errors.New("dial error")}
+	patchedNewMCPClient = baseCounter.dial
+	patchedNewMCPClientWithOptions = optCounter.dial
+	defer func() {
+		patchedNewMCPClient = origBase
+		patchedNewMCPClientWithOptions = origOpts
+	}()
+
+	reg := tool.NewRegistry()
+	err := registerMCPServers(context.Background(), reg, nil, []mcpServer{{
+		Name:               "svc",
+		Spec:               "stdio://dummy",
+		EnabledTools:       []string{"echo"},
+		DisabledTools:      []string{"sum"},
+		ToolTimeoutSeconds: 3,
+	}})
+	if err == nil || !errors.Is(err, optCounter.err) {
+		t.Fatalf("expected options dial error propagated, got %v", err)
+	}
+	if baseCounter.calls != 0 {
+		t.Fatalf("expected default dialer unused, got %d", baseCounter.calls)
+	}
+	if optCounter.calls != 1 {
+		t.Fatalf("expected options dialer called once, got %d", optCounter.calls)
+	}
+	if optCounter.lastOps.ToolTimeout != 3*time.Second {
+		t.Fatalf("expected tool timeout propagated, got %v", optCounter.lastOps.ToolTimeout)
+	}
+	if len(optCounter.lastOps.EnabledTools) != 1 || optCounter.lastOps.EnabledTools[0] != "echo" {
+		t.Fatalf("expected enabled tools propagated, got %+v", optCounter.lastOps.EnabledTools)
+	}
+	if len(optCounter.lastOps.DisabledTools) != 1 || optCounter.lastOps.DisabledTools[0] != "sum" {
+		t.Fatalf("expected disabled tools propagated, got %+v", optCounter.lastOps.DisabledTools)
 	}
 }

--- a/pkg/config/mcp_config_test.go
+++ b/pkg/config/mcp_config_test.go
@@ -35,10 +35,13 @@ func TestValidateSettingsMCPHappyPath(t *testing.T) {
 	settings.Model = "dummy"
 	settings.MCP = &MCPConfig{Servers: map[string]MCPServerConfig{
 		"api": {
-			Type:           "http",
-			URL:            "https://api.example",
-			Headers:        map[string]string{"Authorization": "Bearer x"},
-			TimeoutSeconds: 2,
+			Type:               "http",
+			URL:                "https://api.example",
+			Headers:            map[string]string{"Authorization": "Bearer x"},
+			TimeoutSeconds:     2,
+			EnabledTools:       []string{"tool_a"},
+			DisabledTools:      []string{"tool_b"},
+			ToolTimeoutSeconds: 3,
 		},
 	}}
 
@@ -50,15 +53,21 @@ func TestValidateSettingsMCPHeaderAndTimeoutErrors(t *testing.T) {
 	settings.Model = "dummy"
 	settings.MCP = &MCPConfig{Servers: map[string]MCPServerConfig{
 		"bad": {
-			Type:           "http",
-			URL:            "https://example",
-			TimeoutSeconds: -1,
-			Headers:        map[string]string{"": "value"},
+			Type:               "http",
+			URL:                "https://example",
+			TimeoutSeconds:     -1,
+			ToolTimeoutSeconds: -1,
+			Headers:            map[string]string{"": "value"},
+			EnabledTools:       []string{"echo", "", "echo"},
+			DisabledTools:      []string{"sum", "   ", "sum"},
 		},
 	}}
 
 	err := settings.Validate()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "timeoutSeconds")
+	require.Contains(t, err.Error(), "toolTimeoutSeconds")
 	require.Contains(t, err.Error(), "headers")
+	require.Contains(t, err.Error(), "enabledTools")
+	require.Contains(t, err.Error(), "disabledTools")
 }

--- a/pkg/config/settings_merge.go
+++ b/pkg/config/settings_merge.go
@@ -495,6 +495,8 @@ func cloneMCPServerConfig(src MCPServerConfig) MCPServerConfig {
 	out.Args = mergeStringSlices(nil, src.Args)
 	out.Env = mergeMaps(nil, src.Env)
 	out.Headers = mergeMaps(nil, src.Headers)
+	out.EnabledTools = mergeStringSlices(nil, src.EnabledTools)
+	out.DisabledTools = mergeStringSlices(nil, src.DisabledTools)
 	return out
 }
 

--- a/pkg/config/settings_types.go
+++ b/pkg/config/settings_types.go
@@ -121,13 +121,16 @@ type MCPConfig struct {
 
 // MCPServerConfig describes how to reach an MCP server.
 type MCPServerConfig struct {
-	Type           string            `json:"type"`              // stdio/http/sse
-	Command        string            `json:"command,omitempty"` // for stdio
-	Args           []string          `json:"args,omitempty"`
-	URL            string            `json:"url,omitempty"` // for http/sse
-	Env            map[string]string `json:"env,omitempty"`
-	Headers        map[string]string `json:"headers,omitempty"`
-	TimeoutSeconds int               `json:"timeoutSeconds,omitempty"` // optional per-transport timeout
+	Type               string            `json:"type"`              // stdio/http/sse
+	Command            string            `json:"command,omitempty"` // for stdio
+	Args               []string          `json:"args,omitempty"`
+	URL                string            `json:"url,omitempty"` // for http/sse
+	Env                map[string]string `json:"env,omitempty"`
+	Headers            map[string]string `json:"headers,omitempty"`
+	TimeoutSeconds     int               `json:"timeoutSeconds,omitempty"`     // optional connect/list timeout
+	EnabledTools       []string          `json:"enabledTools,omitempty"`       // optional remote tool allowlist
+	DisabledTools      []string          `json:"disabledTools,omitempty"`      // optional remote tool denylist
+	ToolTimeoutSeconds int               `json:"toolTimeoutSeconds,omitempty"` // optional timeout for each MCP tool call
 }
 
 // MCPServerRule constrains which MCP servers can be enabled.

--- a/pkg/model/openai.go
+++ b/pkg/model/openai.go
@@ -386,8 +386,8 @@ func convertMessagesToOpenAI(msgs []Message, defaults ...string) []openai.ChatCo
 				})
 				continue
 			}
-			content := strings.TrimSpace(msg.Content)
-			if content == "" {
+			content := msg.Content
+			if strings.TrimSpace(content) == "" {
 				content = "."
 			}
 			result = append(result, openai.UserMessage(content))

--- a/pkg/model/openai_test.go
+++ b/pkg/model/openai_test.go
@@ -313,6 +313,18 @@ func TestConvertMessagesToOpenAI(t *testing.T) {
 	}
 }
 
+func TestConvertMessagesToOpenAI_PreservesUserWhitespace(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: "  keep leading and trailing spaces  "},
+	}
+
+	result := convertMessagesToOpenAI(msgs)
+	if len(result) != 1 || result[0].OfUser == nil {
+		t.Fatalf("expected one user message, got %+v", result)
+	}
+	assert.Equal(t, "  keep leading and trailing spaces  ", result[0].OfUser.Content.OfString.Value)
+}
+
 func TestConvertToolsToOpenAI(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/security/resolver_additional_test.go
+++ b/pkg/security/resolver_additional_test.go
@@ -40,12 +40,3 @@ func TestOpenNoFollowRegularFile(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
-
-func TestSupportsNoFollow(t *testing.T) {
-	if runtime.GOOS == "windows" && supportsNoFollow() {
-		t.Fatalf("expected no O_NOFOLLOW on windows")
-	}
-	if runtime.GOOS != "windows" && !supportsNoFollow() {
-		t.Fatalf("expected O_NOFOLLOW support on unix")
-	}
-}

--- a/pkg/security/resolver_test.go
+++ b/pkg/security/resolver_test.go
@@ -155,7 +155,7 @@ func mustHardlink(t *testing.T, oldname, newname string) {
 }
 
 func TestOpenNoFollowMissingPath(t *testing.T) {
-	if !supportsNoFollow() {
+	if runtime.GOOS == "windows" {
 		t.Skip("O_NOFOLLOW unsupported on this platform")
 	}
 	missing := filepath.Join(t.TempDir(), "missing.txt")

--- a/pkg/security/resolver_unix.go
+++ b/pkg/security/resolver_unix.go
@@ -1,7 +1,0 @@
-//go:build !windows
-
-package security
-
-func supportsNoFollow() bool {
-	return true
-}

--- a/pkg/tool/registry_coverage_test.go
+++ b/pkg/tool/registry_coverage_test.go
@@ -70,7 +70,7 @@ func TestRegisterMCPServerConnectContextCanceled(t *testing.T) {
 
 func TestRegisterMCPSessionErrors(t *testing.T) {
 	r := NewRegistry()
-	if err := r.registerMCPSession("srv", "name", nil, nil, nil); err == nil {
+	if err := r.registerMCPSession("srv", "name", nil, nil, nil, MCPServerOptions{}); err == nil {
 		t.Fatalf("expected nil session error")
 	}
 
@@ -81,14 +81,14 @@ func TestRegisterMCPSessionErrors(t *testing.T) {
 	}
 	defer func() { _ = session.Close() }()
 
-	if err := r.registerMCPSession("srv", "name", session, []Tool{}, []string{"x"}); err == nil {
+	if err := r.registerMCPSession("srv", "name", session, []Tool{}, []string{"x"}, MCPServerOptions{}); err == nil {
 		t.Fatalf("expected tool mismatch error")
 	}
 
-	if err := r.registerMCPSession("srv", "name", session, []Tool{&spyTool{name: "echo"}}, []string{"echo"}); err != nil {
+	if err := r.registerMCPSession("srv", "name", session, []Tool{&spyTool{name: "echo"}}, []string{"echo"}, MCPServerOptions{}); err != nil {
 		t.Fatalf("unexpected register error: %v", err)
 	}
-	if err := r.registerMCPSession("srv", "name", session, []Tool{&spyTool{name: "echo"}}, []string{"echo"}); err == nil {
+	if err := r.registerMCPSession("srv", "name", session, []Tool{&spyTool{name: "echo"}}, []string{"echo"}, MCPServerOptions{}); err == nil {
 		t.Fatalf("expected duplicate tool error")
 	}
 }


### PR DESCRIPTION
## Summary

Split from PR #73. Adds MCP tool filtering (`enabledTools`/`disabledTools`) and per-tool timeout configuration. This PR contains all 6 original commits plus all review fixes.

## Changes

**Original commits (all from #73):**
- MCP tool filters and per-tool timeouts in `pkg/tool/registry.go`
- Config types for `enabledTools`/`disabledTools` in settings
- MCP bridge updates for filter support
- All changes from PRs #74, #75, #76 (this is the full PR)

**Review fixes applied (same as #74-#76 plus MCP-specific):**
- All fixes from #74 (Windows security, trace.go, variable shadowing, newShellCommand)
- All fixes from #75 (TaskStore interface improvements)
- All fixes from #76 (multimodal tool message handling)

## Merge order

This PR contains ALL changes and should be merged **last** (after #74, #75, #76). Alternatively, if merging the smaller PRs first, rebase this branch before merging.

**Note:** If #74, #75, #76 are merged first, this PR will have conflicts and needs rebasing. The MCP-specific changes that are unique to this PR are in commit `c710772`.