### PR TITLE
message: include reasoning/tool-result in compaction token estimate

### DIFF
--- a/pkg/message/trimmer.go
+++ b/pkg/message/trimmer.go
@@ -13,6 +13,9 @@ type NaiveCounter struct{}
 // Count implements TokenCounter.
 func (NaiveCounter) Count(msg Message) int {
 	tokens := len(msg.Content)/4 + len(msg.Role)/10
+	// Include assistant reasoning/thinking content so compact decisions can
+	// account for providers that keep thinking blocks in context.
+	tokens += len(msg.ReasoningContent) / 4
 	for _, block := range msg.ContentBlocks {
 		switch block.Type {
 		case ContentBlockText:
@@ -29,6 +32,9 @@ func (NaiveCounter) Count(msg Message) int {
 	}
 	for _, call := range msg.ToolCalls {
 		tokens += len(call.Name)
+		// Tool results are often long and dominate context growth in tool-heavy
+		// sessions; include them in the estimate.
+		tokens += len(call.Result) / 4
 		for k, v := range call.Arguments {
 			tokens += len(k)
 			switch val := v.(type) {

--- a/pkg/message/trimmer_test.go
+++ b/pkg/message/trimmer_test.go
@@ -86,6 +86,17 @@ func TestNaiveCounterEdgeCases(t *testing.T) {
 			want: 3, // len("x") + len("n") + default branch
 		},
 		{
+			name: "reasoning and tool result contribute",
+			msg: Message{
+				ToolCalls: []ToolCall{{
+					Name:   "bash",
+					Result: "12345678",
+				}},
+				ReasoningContent: "abcdefgh",
+			},
+			want: 8, // len("bash") + 8/4 (result) + 8/4 (reasoning)
+		},
+		{
 			name: "enforces minimum token",
 			msg:  Message{},
 			want: 1,


### PR DESCRIPTION
## Background
In a real Telegram gateway session to Minimax, requests failed with:
`400 invalid params, context window exceeds limit (2013)`

Compaction did not trigger because the SDK's naive token estimator under-counted context growth for tool-heavy / reasoning-heavy turns.

## Root cause
`NaiveCounter` did not include:
- assistant `ReasoningContent`
- `ToolCall.Result` payload

For providers that keep thinking blocks and large tool outputs in context, this materially underestimates usage and keeps compaction ratio below threshold.

## Change
- Count `Message.ReasoningContent` in `NaiveCounter`
- Count `ToolCall.Result` in `NaiveCounter`
- Add edge-case test coverage for both fields

## Validation
- `go test ./pkg/message`
- Replayed the affected history: old estimate stayed below compact threshold, new estimate crossed threshold and compaction triggered.
- Downstream gateway verification: Minimax 400 context overflow disappeared after applying this patch.

## Scope
This PR only changes token estimation used for compaction decisions. No protocol or runtime API behavior changes.