### PR TITLE
feat(api): expose session history for external persistence

### DIFF
--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stellarlinkco/agentsdk-go/pkg/config"
 	hooks "github.com/stellarlinkco/agentsdk-go/pkg/hooks"
+	"github.com/stellarlinkco/agentsdk-go/pkg/message"
 	"github.com/stellarlinkco/agentsdk-go/pkg/sandbox"
 	"github.com/stellarlinkco/agentsdk-go/pkg/tool"
 )
@@ -150,7 +151,7 @@ func New(ctx context.Context, opts Options) (*Runtime, error) {
 	opts.SystemPromptBuilder = builder
 	opts.SystemPrompt = builder.Build()
 
-	histories := newHistoryStore(opts.MaxSessions)
+	histories := newHistoryStore(opts.MaxSessions, opts.HistoryLoader)
 
 	rt := &Runtime{
 		opts:      opts,
@@ -356,6 +357,14 @@ func (rt *Runtime) Sandbox() *sandbox.Manager {
 		return nil
 	}
 	return rt.executor.Sandbox()
+}
+
+// SessionHistory returns the in-memory history for a session, or nil.
+func (rt *Runtime) SessionHistory(sessionID string) *message.History {
+	if rt == nil || rt.histories == nil {
+		return nil
+	}
+	return rt.histories.Get(sessionID)
 }
 
 // ----------------- internal helpers -----------------

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stellarlinkco/agentsdk-go/pkg/config"
 	hooks "github.com/stellarlinkco/agentsdk-go/pkg/hooks"
+	"github.com/stellarlinkco/agentsdk-go/pkg/message"
 	"github.com/stellarlinkco/agentsdk-go/pkg/middleware"
 	"github.com/stellarlinkco/agentsdk-go/pkg/model"
 	"github.com/stellarlinkco/agentsdk-go/pkg/runtime/skills"
@@ -162,6 +163,7 @@ type Options struct {
 	MaxTokensEscalation    MaxTokensEscalationConfig
 	MaxSessions            int
 	MaxConcurrentSubagents int
+	HistoryLoader          func(sessionID string) ([]message.Message, error) // loader for session history restoration
 	Tools                  []tool.Tool
 	EnabledBuiltinTools    []string
 	DisallowedTools        []string
@@ -242,6 +244,13 @@ type SandboxReport struct {
 	AllowedPaths   []string
 	AllowedDomains []string
 	ResourceLimits sandbox.ResourceLimits
+}
+
+// WithHistoryLoader sets a function that is called when a new session is created.
+// The loader receives the session ID and should return previously persisted messages,
+// or nil/error if no history exists.
+func WithHistoryLoader(loader func(string) ([]message.Message, error)) func(*Options) {
+	return func(o *Options) { o.HistoryLoader = loader }
 }
 
 func WithMaxSessions(n int) func(*Options) {

--- a/pkg/api/runtime_helpers.go
+++ b/pkg/api/runtime_helpers.go
@@ -316,7 +316,7 @@ type historyStore struct {
 	loader   func(string) ([]message.Message, error)
 }
 
-func newHistoryStore(maxSize int) *historyStore {
+func newHistoryStore(maxSize int, loader func(string) ([]message.Message, error)) *historyStore {
 	if maxSize <= 0 {
 		maxSize = defaultMaxSessions
 	}
@@ -324,6 +324,7 @@ func newHistoryStore(maxSize int) *historyStore {
 		data:     map[string]*message.History{},
 		lastUsed: map[string]time.Time{},
 		maxSize:  maxSize,
+		loader:   loader,
 	}
 }
 

--- a/pkg/api/session_cleanup_test.go
+++ b/pkg/api/session_cleanup_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSessionEvictionCleansToolOutputDir(t *testing.T) {
-	store := newHistoryStore(1)
+	store := newHistoryStore(1, nil)
 	sessionID := "session-to-evict"
 	dir := toolOutputSessionDir(sessionID)
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
@@ -36,7 +36,7 @@ func TestSessionEvictionCleansToolOutputDir(t *testing.T) {
 }
 
 func TestSessionEvictionInvokesCallbackWhenPresent(t *testing.T) {
-	store := newHistoryStore(1)
+	store := newHistoryStore(1, nil)
 	var evicted []string
 
 	store.onEvict = func(id string) {
@@ -53,7 +53,7 @@ func TestSessionEvictionInvokesCallbackWhenPresent(t *testing.T) {
 }
 
 func TestRuntimeCloseCleansToolOutputDirs(t *testing.T) {
-	rt := &Runtime{histories: newHistoryStore(0)}
+	rt := &Runtime{histories: newHistoryStore(0, nil)}
 
 	sessions := []string{"sess-a", "sess-b"}
 	for _, sessionID := range sessions {

--- a/pkg/api/subagent_async_test.go
+++ b/pkg/api/subagent_async_test.go
@@ -47,7 +47,7 @@ func TestRuntimeBindsSubagentCompletionToHooksAndHistory(t *testing.T) {
 
 	rt := &Runtime{
 		opts:      Options{subMgr: mgr},
-		histories: newHistoryStore(4),
+		histories: newHistoryStore(4, nil),
 		hooks:     exec,
 	}
 	rt.bindSubagentCallbacks()
@@ -127,7 +127,7 @@ func TestRuntimeCanDisableSubagentSummaryInjection(t *testing.T) {
 
 	rt := &Runtime{
 		opts:      Options{DisableSubagentSummary: true, subMgr: mgr},
-		histories: newHistoryStore(4),
+		histories: newHistoryStore(4, nil),
 		hooks:     hooks.NewExecutor(),
 	}
 	rt.bindSubagentCallbacks()


### PR DESCRIPTION
## 概述

  允许用户在外部保存和恢复 session 对话历史，使 agent 重启后能
  恢复之前的对话上下文。

  ## 变更内容

  - 新增 `Options.HistoryLoader` 字段和 `WithHistoryLoader` 函数选项，
    用户可注入一个回调函数，在新 session 创建时从外部存储加载历史消息。
  - 将 loader 传入 `historyStore`，在 session 创建时自动调用 loader 恢复消息。
  - 新增 `Runtime.SessionHistory(sessionID)` 公开方法，外部代码
    可读取当前 session 的内存历史用于持久化。
  - 更新已有测试用例，传入 nil loader。

  ## 使用方式

  ```go
  // 创建 agent 时指定历史加载器
  rt, _ := api.New(ctx, api.WithHistoryLoader(func(id string) ([]message.Message, error) {
      return myDB.LoadMessages(id)
  }))

  // 定期或退出前持久化当前历史
  hist := rt.SessionHistory("session-1")
  myDB.SaveMessages("session-1", hist.List())