### PR TITLE
feat(glob): replace filepath.Glob with doublestar for bash-style ** s…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.18.0
+	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/anthropics/anthropic-sdk-go v1.18.0 h1:jfxRA7AqZoCm83nHO/OVQp8xuwjUKtBziEdMbfmofHU=
 github.com/anthropics/anthropic-sdk-go v1.18.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
+github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
+github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/tool/builtin/glob.go
+++ b/pkg/tool/builtin/glob.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/stellarlinkco/agentsdk-go/pkg/gitignore"
 	"github.com/stellarlinkco/agentsdk-go/pkg/sandbox"
 	"github.com/stellarlinkco/agentsdk-go/pkg/tool"
@@ -118,7 +119,7 @@ func (g *GlobTool) Execute(ctx context.Context, params map[string]interface{}) (
 		g.gitignoreMatcher, _ = gitignore.NewMatcher(g.root) //nolint:errcheck // best-effort gitignore
 	}
 
-	matches, err := filepath.Glob(absPattern)
+	matches, err := doublestar.FilepathGlob(absPattern)
 	if err != nil {
 		return nil, fmt.Errorf("glob failed: %w", err)
 	}
@@ -148,7 +149,9 @@ func (g *GlobTool) Execute(ctx context.Context, params map[string]interface{}) (
 		}
 	}
 
-	truncated := len(matches) > len(results) || len(results) >= g.maxResults
+	// len(matches) > len(results) 会把 gitignore 过滤掉的结果也算作截断
+	// 仅在结果数达到上限时才报告截断
+	truncated := len(results) >= g.maxResults
 
 	return &tool.ToolResult{
 		Success: true,
@@ -223,7 +226,10 @@ func (g *GlobTool) combinePattern(dir, pattern string) (string, error) {
 	}
 	candidate = filepath.Clean(candidate)
 	parent := filepath.Dir(candidate)
-	if g.policy != nil {
+	if strings.ContainsAny(parent, "*?[") {
+		// Pattern contains wildcards in directory portion; skip prefix
+		// validation — FilepathGlob will resolve the pattern at execution.
+	} else if g.policy != nil {
 		if err := g.policy.Validate(parent); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
  ## 概述

  将 glob tool 的底层引擎从 Go 标准库 `filepath.Glob` 替换为 `doublestar.FilepathGlob`，
  使 `**` 支持「匹配零段或多段路径」的 bash 风格语义。（大模型默认会发起 bash 风格的 glob 调用）

  ## 问题

  Go `filepath.Glob` 的 `**` 不具备跨层级语义。`**/scripts/*.ts` 在仓库根下存在
  `scripts/foo.ts` 时会返回零匹配，与 bash glob 的行为不一致。

  ## 变更内容

  ### 1. glob 引擎替换 (`pkg/tool/builtin/glob.go`)

  - `filepath.Glob` → `doublestar.FilepathGlob`：`**` 匹配零段或多段目录。
  - `combinePattern` 增加通配符父目录跳过验证：pattern 含 `**` 时 `filepath.Dir`
    会得到不存在的路径，sandbox 验证会误杀。检测到父目录含 `*?[` 时跳过预检，
    安全性由结果的逐文件 `policy.Validate` 保证，不变。
  - 修正 `truncated` 计算：不再把 gitignore 过滤掉的结果算作截断。

  ### 2. 新增依赖

  - `github.com/bmatcuk/doublestar/v4` v4.9.1