### PR TITLE
fix(api): harden session history persistence

### DIFF
--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -359,12 +359,12 @@ func (rt *Runtime) Sandbox() *sandbox.Manager {
 	return rt.executor.Sandbox()
 }
 
-// SessionHistory returns the in-memory history for a session, or nil.
-func (rt *Runtime) SessionHistory(sessionID string) *message.History {
+// SessionHistory returns a cloned snapshot of an existing session history.
+func (rt *Runtime) SessionHistory(sessionID string) ([]message.Message, bool) {
 	if rt == nil || rt.histories == nil {
-		return nil
+		return nil, false
 	}
-	return rt.histories.Get(sessionID)
+	return rt.histories.Snapshot(sessionID)
 }
 
 // ----------------- internal helpers -----------------

--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stellarlinkco/agentsdk-go/pkg/config"
 	hooks "github.com/stellarlinkco/agentsdk-go/pkg/hooks"
+	"github.com/stellarlinkco/agentsdk-go/pkg/message"
 	"github.com/stellarlinkco/agentsdk-go/pkg/sandbox"
 	"github.com/stellarlinkco/agentsdk-go/pkg/tool"
 )
@@ -150,7 +151,7 @@ func New(ctx context.Context, opts Options) (*Runtime, error) {
 	opts.SystemPromptBuilder = builder
 	opts.SystemPrompt = builder.Build()
 
-	histories := newHistoryStore(opts.MaxSessions)
+	histories := newHistoryStore(opts.MaxSessions, opts.HistoryLoader)
 
 	rt := &Runtime{
 		opts:      opts,
@@ -356,6 +357,14 @@ func (rt *Runtime) Sandbox() *sandbox.Manager {
 		return nil
 	}
 	return rt.executor.Sandbox()
+}
+
+// SessionHistory returns the in-memory history for a session, or nil.
+func (rt *Runtime) SessionHistory(sessionID string) *message.History {
+	if rt == nil || rt.histories == nil {
+		return nil
+	}
+	return rt.histories.Get(sessionID)
 }
 
 // ----------------- internal helpers -----------------

--- a/pkg/api/agent_compact_precheck_test.go
+++ b/pkg/api/agent_compact_precheck_test.go
@@ -10,12 +10,15 @@ func TestRuntimePrepare_PrecheckCompactsHistory(t *testing.T) {
 	rt := newTestRuntime(t, staticModel{content: "ok"}, auto)
 
 	sessionID := "sess"
-	hist := rt.histories.Get(sessionID)
+	hist, err := rt.histories.Get(sessionID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 	for i := 0; i < 10; i++ {
 		hist.Append(msgWithTokens("user", 20))
 	}
 
-	_, err := rt.Run(context.Background(), Request{Prompt: "hello", SessionID: sessionID})
+	_, err = rt.Run(context.Background(), Request{Prompt: "hello", SessionID: sessionID})
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}

--- a/pkg/api/history_loader_test.go
+++ b/pkg/api/history_loader_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stellarlinkco/agentsdk-go/pkg/message"
+	"github.com/stellarlinkco/agentsdk-go/pkg/model"
+)
+
+type historyCaptureModel struct {
+	content  string
+	called   bool
+	requests []model.Request
+}
+
+func (m *historyCaptureModel) Complete(context.Context, model.Request) (*model.Response, error) {
+	return nil, errors.New("Complete should not be called directly")
+}
+
+func (m *historyCaptureModel) CompleteStream(_ context.Context, req model.Request, cb model.StreamHandler) error {
+	m.called = true
+	m.requests = append(m.requests, req)
+	return cb(model.StreamResult{
+		Final: true,
+		Response: &model.Response{
+			Message: model.Message{Role: "assistant", Content: m.content},
+		},
+	})
+}
+
+func TestHistoryLoaderRestoresSessionHistory(t *testing.T) {
+	mdl := &historyCaptureModel{content: "ok"}
+	rt, err := New(context.Background(), Options{
+		ProjectRoot:         t.TempDir(),
+		Model:               mdl,
+		EnabledBuiltinTools: []string{},
+		RulesEnabled:        boolPtr(false),
+		HistoryLoader: func(sessionID string) ([]message.Message, error) {
+			if sessionID != "sess" {
+				t.Fatalf("sessionID = %q, want sess", sessionID)
+			}
+			return []message.Message{{Role: "user", Content: "previous"}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	if _, err := rt.Run(context.Background(), Request{SessionID: "sess", Prompt: "next"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(mdl.requests) != 1 {
+		t.Fatalf("model requests = %d, want 1", len(mdl.requests))
+	}
+	msgs := mdl.requests[0].Messages
+	if len(msgs) != 2 || msgs[0].Content != "previous" || msgs[1].Content != "next" {
+		t.Fatalf("model messages = %+v", msgs)
+	}
+
+	snapshot, ok := rt.SessionHistory("sess")
+	if !ok {
+		t.Fatal("expected session snapshot")
+	}
+	if len(snapshot) != 3 || snapshot[0].Content != "previous" || snapshot[1].Content != "next" || snapshot[2].Content != "ok" {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+}
+
+func TestHistoryLoaderErrorStopsRun(t *testing.T) {
+	boom := errors.New("boom")
+	mdl := &historyCaptureModel{content: "ok"}
+	rt, err := New(context.Background(), Options{
+		ProjectRoot:         t.TempDir(),
+		Model:               mdl,
+		EnabledBuiltinTools: []string{},
+		RulesEnabled:        boolPtr(false),
+		HistoryLoader: func(string) ([]message.Message, error) {
+			return nil, boom
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	_, err = rt.Run(context.Background(), Request{SessionID: "sess", Prompt: "next"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Run error = %v, want boom", err)
+	}
+	if mdl.called {
+		t.Fatal("model was called after loader failure")
+	}
+	if _, ok := rt.SessionHistory("sess"); ok {
+		t.Fatal("loader failure should not create session history")
+	}
+}
+
+func TestSessionHistoryDoesNotCreateMissingSession(t *testing.T) {
+	rt := newTestRuntime(t, staticModel{content: "ok"}, CompactConfig{})
+
+	if _, err := rt.Run(context.Background(), Request{SessionID: "keep", Prompt: "hello"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, ok := rt.SessionHistory("missing"); ok {
+		t.Fatal("missing session unexpectedly returned history")
+	}
+
+	ids := rt.histories.SessionIDs()
+	if len(ids) != 1 || ids[0] != "keep" {
+		t.Fatalf("session IDs = %v, want [keep]", ids)
+	}
+}
+
+func TestSessionHistoryReturnsSnapshotClone(t *testing.T) {
+	rt := newTestRuntime(t, staticModel{content: "ok"}, CompactConfig{})
+	hist, err := rt.histories.Get("sess")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	hist.Append(message.Message{
+		Role:    "user",
+		Content: "original",
+		Metadata: map[string]any{
+			"key": "value",
+		},
+		ToolCalls: []message.ToolCall{{
+			ID:        "call-1",
+			Name:      "tool",
+			Arguments: map[string]any{"arg": "value"},
+		}},
+	})
+
+	snapshot, ok := rt.SessionHistory("sess")
+	if !ok || len(snapshot) != 1 {
+		t.Fatalf("snapshot = %+v, ok=%v", snapshot, ok)
+	}
+	snapshot[0].Content = "mutated"
+	snapshot[0].Metadata["key"] = "mutated"
+	snapshot[0].ToolCalls[0].Arguments["arg"] = "mutated"
+
+	again, ok := rt.SessionHistory("sess")
+	if !ok || len(again) != 1 {
+		t.Fatalf("second snapshot = %+v, ok=%v", again, ok)
+	}
+	if again[0].Content != "original" || again[0].Metadata["key"] != "value" || again[0].ToolCalls[0].Arguments["arg"] != "value" {
+		t.Fatalf("history was mutated through snapshot: %+v", again[0])
+	}
+	if strings.Contains(again[0].Content, "mutated") {
+		t.Fatalf("unexpected mutated content: %+v", again[0])
+	}
+}

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -163,7 +163,7 @@ type Options struct {
 	MaxTokensEscalation    MaxTokensEscalationConfig
 	MaxSessions            int
 	MaxConcurrentSubagents int
-	HistoryLoader          func(sessionID string) ([]message.Message, error) // loader for session history restoration
+	HistoryLoader          func(sessionID string) ([]message.Message, error) // restores persisted session history
 	Tools                  []tool.Tool
 	EnabledBuiltinTools    []string
 	DisallowedTools        []string
@@ -248,7 +248,7 @@ type SandboxReport struct {
 
 // WithHistoryLoader sets a function that is called when a new session is created.
 // The loader receives the session ID and should return previously persisted messages,
-// or nil/error if no history exists.
+// or nil, nil if no history exists.
 func WithHistoryLoader(loader func(string) ([]message.Message, error)) func(*Options) {
 	return func(o *Options) { o.HistoryLoader = loader }
 }

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stellarlinkco/agentsdk-go/pkg/config"
 	hooks "github.com/stellarlinkco/agentsdk-go/pkg/hooks"
+	"github.com/stellarlinkco/agentsdk-go/pkg/message"
 	"github.com/stellarlinkco/agentsdk-go/pkg/middleware"
 	"github.com/stellarlinkco/agentsdk-go/pkg/model"
 	"github.com/stellarlinkco/agentsdk-go/pkg/runtime/skills"
@@ -162,6 +163,7 @@ type Options struct {
 	MaxTokensEscalation    MaxTokensEscalationConfig
 	MaxSessions            int
 	MaxConcurrentSubagents int
+	HistoryLoader          func(sessionID string) ([]message.Message, error) // loader for session history restoration
 	Tools                  []tool.Tool
 	EnabledBuiltinTools    []string
 	DisallowedTools        []string
@@ -242,6 +244,13 @@ type SandboxReport struct {
 	AllowedPaths   []string
 	AllowedDomains []string
 	ResourceLimits sandbox.ResourceLimits
+}
+
+// WithHistoryLoader sets a function that is called when a new session is created.
+// The loader receives the session ID and should return previously persisted messages,
+// or nil/error if no history exists.
+func WithHistoryLoader(loader func(string) ([]message.Message, error)) func(*Options) {
+	return func(o *Options) { o.HistoryLoader = loader }
 }
 
 func WithMaxSessions(n int) func(*Options) {

--- a/pkg/api/runtime_helpers.go
+++ b/pkg/api/runtime_helpers.go
@@ -316,7 +316,7 @@ type historyStore struct {
 	loader   func(string) ([]message.Message, error)
 }
 
-func newHistoryStore(maxSize int) *historyStore {
+func newHistoryStore(maxSize int, loader func(string) ([]message.Message, error)) *historyStore {
 	if maxSize <= 0 {
 		maxSize = defaultMaxSessions
 	}
@@ -324,6 +324,7 @@ func newHistoryStore(maxSize int) *historyStore {
 		data:     map[string]*message.History{},
 		lastUsed: map[string]time.Time{},
 		maxSize:  maxSize,
+		loader:   loader,
 	}
 }
 

--- a/pkg/api/runtime_helpers.go
+++ b/pkg/api/runtime_helpers.go
@@ -328,39 +328,52 @@ func newHistoryStore(maxSize int, loader func(string) ([]message.Message, error)
 	}
 }
 
-func (s *historyStore) Get(id string) *message.History {
+func (s *historyStore) Get(id string) (*message.History, error) {
 	if strings.TrimSpace(id) == "" {
 		id = defaultSessionID(defaultEntrypoint)
 	}
 	s.mu.Lock()
-	now := time.Now()
 	if hist, ok := s.data[id]; ok {
+		s.lastUsed[id] = time.Now()
+		s.mu.Unlock()
+		return hist, nil
+	}
+	loader := s.loader
+	s.mu.Unlock()
+
+	hist := message.NewHistory()
+	if loader != nil {
+		loaded, err := loader(id)
+		if err != nil {
+			return nil, fmt.Errorf("api: load history for session %q: %w", id, err)
+		}
+		if len(loaded) > 0 {
+			hist.Replace(loaded)
+		}
+	}
+
+	s.mu.Lock()
+	now := time.Now()
+	if existing, ok := s.data[id]; ok {
 		s.lastUsed[id] = now
 		s.mu.Unlock()
-		return hist
+		return existing, nil
 	}
-	hist := message.NewHistory()
 	s.data[id] = hist
 	s.lastUsed[id] = now
 	onEvict := s.onEvict
-	loader := s.loader
 	evicted := ""
 	if len(s.data) > s.maxSize {
 		evicted = s.evictOldest()
 	}
 	s.mu.Unlock()
-	if loader != nil {
-		if loaded, err := loader(id); err == nil && len(loaded) > 0 {
-			hist.Replace(loaded)
-		}
-	}
 	if evicted != "" {
 		cleanupToolOutputSessionDir(evicted) //nolint:errcheck
 		if onEvict != nil {
 			onEvict(evicted)
 		}
 	}
-	return hist
+	return hist, nil
 }
 
 func (s *historyStore) Loaded(id string) (*message.History, bool) {
@@ -378,6 +391,22 @@ func (s *historyStore) Loaded(id string) (*message.History, bool) {
 		s.lastUsed[id] = time.Now()
 	}
 	return hist, ok
+}
+
+func (s *historyStore) Snapshot(id string) ([]message.Message, bool) {
+	if s == nil {
+		return nil, false
+	}
+	if strings.TrimSpace(id) == "" {
+		id = defaultSessionID(defaultEntrypoint)
+	}
+	s.mu.Lock()
+	hist, ok := s.data[id]
+	s.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+	return hist.All(), true
 }
 
 func (s *historyStore) evictOldest() string {

--- a/pkg/api/runtime_internal.go
+++ b/pkg/api/runtime_internal.go
@@ -51,7 +51,10 @@ func (rt *Runtime) prepare(ctx context.Context, req Request) (preparedRun, error
 		normalized.RequestID = uuid.New().String()
 	}
 
-	history := rt.histories.Get(normalized.SessionID)
+	history, err := rt.histories.Get(normalized.SessionID)
+	if err != nil {
+		return preparedRun{}, err
+	}
 	recorder := defaultHookRecorder()
 
 	activation := normalized.activationContext(prompt)

--- a/pkg/api/session_cleanup_test.go
+++ b/pkg/api/session_cleanup_test.go
@@ -22,9 +22,13 @@ func TestSessionEvictionCleansToolOutputDir(t *testing.T) {
 		t.Fatalf("write dummy output: %v", err)
 	}
 
-	store.Get(sessionID)
+	if _, err := store.Get(sessionID); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 	time.Sleep(100 * time.Microsecond)
-	store.Get("session-to-keep")
+	if _, err := store.Get("session-to-keep"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 
 	ids := store.SessionIDs()
 	if len(ids) != 1 || ids[0] != "session-to-keep" {
@@ -43,9 +47,13 @@ func TestSessionEvictionInvokesCallbackWhenPresent(t *testing.T) {
 		evicted = append(evicted, id)
 	}
 
-	store.Get("session-to-evict")
+	if _, err := store.Get("session-to-evict"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 	time.Sleep(100 * time.Microsecond)
-	store.Get("session-to-keep")
+	if _, err := store.Get("session-to-keep"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 
 	if len(evicted) != 1 || evicted[0] != "session-to-evict" {
 		t.Fatalf("evicted=%v, want [session-to-evict]", evicted)
@@ -57,7 +65,9 @@ func TestRuntimeCloseCleansToolOutputDirs(t *testing.T) {
 
 	sessions := []string{"sess-a", "sess-b"}
 	for _, sessionID := range sessions {
-		rt.histories.Get(sessionID)
+		if _, err := rt.histories.Get(sessionID); err != nil {
+			t.Fatalf("Get: %v", err)
+		}
 		dir := toolOutputSessionDir(sessionID)
 		t.Cleanup(func() { _ = os.RemoveAll(dir) })
 

--- a/pkg/api/session_cleanup_test.go
+++ b/pkg/api/session_cleanup_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSessionEvictionCleansToolOutputDir(t *testing.T) {
-	store := newHistoryStore(1)
+	store := newHistoryStore(1, nil)
 	sessionID := "session-to-evict"
 	dir := toolOutputSessionDir(sessionID)
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
@@ -36,7 +36,7 @@ func TestSessionEvictionCleansToolOutputDir(t *testing.T) {
 }
 
 func TestSessionEvictionInvokesCallbackWhenPresent(t *testing.T) {
-	store := newHistoryStore(1)
+	store := newHistoryStore(1, nil)
 	var evicted []string
 
 	store.onEvict = func(id string) {
@@ -53,7 +53,7 @@ func TestSessionEvictionInvokesCallbackWhenPresent(t *testing.T) {
 }
 
 func TestRuntimeCloseCleansToolOutputDirs(t *testing.T) {
-	rt := &Runtime{histories: newHistoryStore(0)}
+	rt := &Runtime{histories: newHistoryStore(0, nil)}
 
 	sessions := []string{"sess-a", "sess-b"}
 	for _, sessionID := range sessions {

--- a/pkg/api/subagent_async_test.go
+++ b/pkg/api/subagent_async_test.go
@@ -47,7 +47,7 @@ func TestRuntimeBindsSubagentCompletionToHooksAndHistory(t *testing.T) {
 
 	rt := &Runtime{
 		opts:      Options{subMgr: mgr},
-		histories: newHistoryStore(4),
+		histories: newHistoryStore(4, nil),
 		hooks:     exec,
 	}
 	rt.bindSubagentCallbacks()
@@ -127,7 +127,7 @@ func TestRuntimeCanDisableSubagentSummaryInjection(t *testing.T) {
 
 	rt := &Runtime{
 		opts:      Options{DisableSubagentSummary: true, subMgr: mgr},
-		histories: newHistoryStore(4),
+		histories: newHistoryStore(4, nil),
 		hooks:     hooks.NewExecutor(),
 	}
 	rt.bindSubagentCallbacks()

--- a/pkg/api/subagent_async_test.go
+++ b/pkg/api/subagent_async_test.go
@@ -52,7 +52,10 @@ func TestRuntimeBindsSubagentCompletionToHooksAndHistory(t *testing.T) {
 	}
 	rt.bindSubagentCallbacks()
 
-	history := rt.histories.Get("sess")
+	history, err := rt.histories.Get("sess")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 	history.Append(message.Message{Role: "user", Content: "start"})
 
 	taskID, err := mgr.DispatchAsync(subagents.WithContext(context.Background(), subagents.Context{SessionID: "sess"}), "worker", "inspect repo")
@@ -132,7 +135,10 @@ func TestRuntimeCanDisableSubagentSummaryInjection(t *testing.T) {
 	}
 	rt.bindSubagentCallbacks()
 
-	history := rt.histories.Get("sess")
+	history, err := rt.histories.Get("sess")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
 	history.Append(message.Message{Role: "user", Content: "start"})
 
 	taskID, err := mgr.DispatchAsync(subagents.WithContext(context.Background(), subagents.Context{SessionID: "sess"}), "worker", "inspect repo")


### PR DESCRIPTION
## Summary
- Replaces and hardens PR #92's external session history persistence API.
- Returns cloned session history snapshots instead of mutable internal history pointers.
- Surfaces history loader failures and adds focused regression coverage for loader restore/error/snapshot behavior.

## Test plan
- [x] go test ./test/closedloop
- [x] go test ./...
- [x] go build ./...

Generated with SWE-Agent.ai

Co-Authored-By: SWE-Agent.ai <noreply@swe-agent.ai>