### PR TITLE
feat(middleware): add StreamMiddleware for real-time agent text deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,19 @@ The SDK exposes interception at critical stages of request handling:
 ```
 User request
   ↓
-before_agent  ← Request validation, audit logging
+before_agent      ← Request validation, audit logging
+  ↓
+agent_text_delta  ← Real-time streaming text deltas (optional, via StreamMiddleware)
   ↓
 Agent loop
   ↓
-before_tool   ← Tool parameter validation
+before_tool       ← Tool parameter validation
   ↓
 Tool execution
   ↓
-after_tool    ← Result post-processing
+after_tool        ← Result post-processing
   ↓
-after_agent   ← Response formatting, metrics collection
+after_agent       ← Response formatting, metrics collection
   ↓
 User response
 ```
@@ -603,6 +605,10 @@ customMiddleware := middleware.Funcs{
     },
     OnAfterTool: func(ctx context.Context, st *middleware.State) error {
         // After tool execution; st.ToolResult holds the agent.ToolResult
+        return nil
+    },
+    OnAgentTextDelta: func(ctx context.Context, st *middleware.State, delta string) error {
+        // Real-time streaming text delta during model inference
         return nil
     },
 }

--- a/pkg/api/model_recovery.go
+++ b/pkg/api/model_recovery.go
@@ -158,7 +158,19 @@ func collectStreamWithTimeout(ctx context.Context, mdl model.Model, req model.Re
 
 func runStreamCollection(ctx context.Context, mdl model.Model, req model.Request, progress chan<- struct{}) streamOutcome {
 	var final *model.Response
+	deltaHandler := textDeltaHandlerFromCtx(ctx)
+	reasoningEmit := streamEmitFromContext(ctx)
 	err := mdl.CompleteStream(ctx, req, func(sr model.StreamResult) error {
+		if sr.IsReasoning {
+			// 将 reasoning delta 推送到 StreamEvent 通道，供 stream_bridge 投递到 DeltaHandler
+			if reasoningEmit != nil && sr.Delta != "" {
+				reasoningEmit(ctx, StreamEvent{Type: EventReasoningDelta, Delta: &Delta{Text: sr.Delta}})
+			}
+		} else if deltaHandler != nil && sr.Delta != "" {
+			if err := deltaHandler(sr.Delta); err != nil {
+				return err
+			}
+		}
 		if progress != nil {
 			select {
 			case progress <- struct{}{}:
@@ -226,6 +238,17 @@ func nextEscalatedMaxTokens(current, ceiling int) int {
 		return current
 	}
 	return next
+}
+
+func textDeltaHandlerFromCtx(ctx context.Context) model.TextDeltaHandler {
+	if ctx == nil {
+		return nil
+	}
+	h, ok := ctx.Value(model.TextDeltaHandlerKey).(model.TextDeltaHandler)
+	if !ok {
+		return nil
+	}
+	return h
 }
 
 func (s streamOutcome) String() string {

--- a/pkg/api/runtime_internal.go
+++ b/pkg/api/runtime_internal.go
@@ -246,7 +246,12 @@ func (rt *Runtime) runLoop(prep preparedRun, mdl model.Model, hookAdapter *runti
 			return last, err
 		}
 
-		resp, err := rt.completeWithRecovery(ctx, mdl, req, prep.history, tracer, agentSpan, prep.normalized)
+		// 将流式文本增量回调注入 context,供 CompleteStream 内部调用
+		streamCtx := context.WithValue(ctx, model.TextDeltaHandlerKey, model.TextDeltaHandler(func(delta string) error {
+			return chain.ExecuteStreamDelta(ctx, state, delta)
+		}))
+
+		resp, err := rt.completeWithRecovery(streamCtx, mdl, req, prep.history, tracer, agentSpan, prep.normalized)
 		if err != nil {
 			runErr = err
 			return last, err

--- a/pkg/api/stream.go
+++ b/pkg/api/stream.go
@@ -27,6 +27,7 @@ const (
 	EventToolExecutionStart  = "tool_execution_start"
 	EventToolExecutionOutput = "tool_execution_output"
 	EventToolExecutionResult = "tool_execution_result"
+	EventReasoningDelta      = "reasoning_delta"
 	EventError               = "error"
 )
 

--- a/pkg/middleware/chain.go
+++ b/pkg/middleware/chain.go
@@ -83,6 +83,26 @@ func (c *Chain) Execute(ctx context.Context, stage Stage, st *State) error {
 	return nil
 }
 
+// ExecuteStreamDelta calls AgentTextDelta on every middleware that
+// implements StreamMiddleware. Stops on the first error.
+func (c *Chain) ExecuteStreamDelta(ctx context.Context, st *State, delta string) error {
+	c.mu.RLock()
+	mws := make([]Middleware, len(c.middlewares))
+	copy(mws, c.middlewares)
+	c.mu.RUnlock()
+
+	for _, mw := range mws {
+		sm, ok := mw.(StreamMiddleware)
+		if !ok {
+			continue
+		}
+		if err := sm.AgentTextDelta(ctx, st, delta); err != nil {
+			return fmt.Errorf("middleware %s AgentTextDelta failed: %w", middlewareName(mw), err)
+		}
+	}
+	return nil
+}
+
 func (c *Chain) runWithTimeout(ctx context.Context, fn func(context.Context) error, mw Middleware) error {
 	if c.timeout <= 0 {
 		return fn(ctx)

--- a/pkg/middleware/types.go
+++ b/pkg/middleware/types.go
@@ -25,8 +25,8 @@ type State struct {
 	Values      map[string]any
 }
 
-// Middleware defines all four interception points. Implementations may
-// no-op individual methods when the hook is not needed.
+// Middleware defines interception points for the agent runtime.
+// Implementations may no-op individual methods when the hook is not needed.
 type Middleware interface {
 	Name() string
 	BeforeAgent(ctx context.Context, st *State) error
@@ -35,15 +35,23 @@ type Middleware interface {
 	AfterAgent(ctx context.Context, st *State) error
 }
 
+// StreamMiddleware is an optional extension for middleware that want
+// real-time text deltas during model streaming. The Chain calls
+// AgentTextDelta for each middleware that implements this interface.
+type StreamMiddleware interface {
+	AgentTextDelta(ctx context.Context, st *State, delta string) error
+}
+
 // Funcs is a helper that turns a set of function pointers into a Middleware.
 // Unspecified hooks default to no-ops.
 type Funcs struct {
 	Identifier string
 
-	OnBeforeAgent func(ctx context.Context, st *State) error
-	OnBeforeTool  func(ctx context.Context, st *State) error
-	OnAfterTool   func(ctx context.Context, st *State) error
-	OnAfterAgent  func(ctx context.Context, st *State) error
+	OnBeforeAgent    func(ctx context.Context, st *State) error
+	OnBeforeTool     func(ctx context.Context, st *State) error
+	OnAfterTool      func(ctx context.Context, st *State) error
+	OnAfterAgent     func(ctx context.Context, st *State) error
+	OnAgentTextDelta func(ctx context.Context, st *State, delta string) error
 }
 
 func (f Funcs) Name() string {
@@ -79,4 +87,11 @@ func (f Funcs) AfterAgent(ctx context.Context, st *State) error {
 		return nil
 	}
 	return f.OnAfterAgent(ctx, st)
+}
+
+func (f Funcs) AgentTextDelta(ctx context.Context, st *State, delta string) error {
+	if f.OnAgentTextDelta == nil {
+		return nil
+	}
+	return f.OnAgentTextDelta(ctx, st, delta)
 }

--- a/pkg/model/anthropic.go
+++ b/pkg/model/anthropic.go
@@ -236,6 +236,12 @@ func (m *anthropicModel) CompleteStream(ctx context.Context, req Request, cb Str
 						return err
 					}
 				}
+				// 透传 thinking delta（如 Claude 的 interleaved-thinking）
+				if thinkingDelta := ev.Delta.AsThinkingDelta().Thinking; thinkingDelta != "" {
+					if err := cb(StreamResult{Delta: thinkingDelta, IsReasoning: true}); err != nil {
+						return err
+					}
+				}
 			case anthropicsdk.ContentBlockStopEvent:
 				if tool := extractToolCall(final); tool != nil {
 					if err := cb(StreamResult{ToolCall: tool}); err != nil {
@@ -421,7 +427,7 @@ func convertMessages(msgs []Message, enableCache bool, defaults ...string) ([]an
 			} else {
 				text := msg.Content
 				if strings.TrimSpace(text) == "" {
-					text = "."
+					text = "\u200b"
 				}
 				content = []anthropicsdk.ContentBlockParamUnion{
 					anthropicsdk.NewTextBlock(text),
@@ -438,7 +444,7 @@ func convertMessages(msgs []Message, enableCache bool, defaults ...string) ([]an
 		messageParams = append(messageParams, anthropicsdk.MessageParam{
 			Role: anthropicsdk.MessageParamRoleUser,
 			Content: []anthropicsdk.ContentBlockParamUnion{
-				anthropicsdk.NewTextBlock("."),
+				anthropicsdk.NewTextBlock("\u200b"),
 			},
 		})
 	}
@@ -496,7 +502,7 @@ func buildAssistantContent(msg Message) []anthropicsdk.ContentBlockParamUnion {
 		blocks = append(blocks, anthropicsdk.NewToolUseBlock(id, cloneValue(call.Arguments), name))
 	}
 	if len(blocks) == 0 {
-		blocks = append(blocks, anthropicsdk.NewTextBlock("."))
+		blocks = append(blocks, anthropicsdk.NewTextBlock("\u200b"))
 	}
 	return blocks
 }
@@ -534,7 +540,7 @@ func convertContentBlocks(blocks []ContentBlock) []anthropicsdk.ContentBlockPara
 		case ContentBlockText:
 			text := b.Text
 			if strings.TrimSpace(text) == "" {
-				text = "."
+				text = "\u200b"
 			}
 			out = append(out, anthropicsdk.NewTextBlock(text))
 		case ContentBlockImage:
@@ -552,7 +558,7 @@ func convertContentBlocks(blocks []ContentBlock) []anthropicsdk.ContentBlockPara
 		}
 	}
 	if len(out) == 0 {
-		out = append(out, anthropicsdk.NewTextBlock("."))
+		out = append(out, anthropicsdk.NewTextBlock("\u200b"))
 	}
 	return out
 }

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -102,10 +102,11 @@ type Response struct {
 
 // StreamResult delivers incremental updates during streaming calls.
 type StreamResult struct {
-	Delta    string
-	ToolCall *ToolCall
-	Final    bool
-	Response *Response
+	Delta       string
+	ToolCall    *ToolCall
+	Final       bool
+	Response    *Response
+	IsReasoning bool // Delta 为 reasoning/thinking 内容（非回答文本）
 }
 
 // StreamHandler consumes streaming updates in order.

--- a/pkg/model/middleware_state.go
+++ b/pkg/model/middleware_state.go
@@ -13,6 +13,18 @@ const (
 	MiddlewareStateKey = middlewareStateKey
 )
 
+// TextDeltaHandler 是流式文本增量的回调签名。当模型流式输出文本时,
+// runtime 通过 context 传递此回调,供 CompleteStream 内部调用。
+type TextDeltaHandler func(delta string) error
+
+type textDeltaHandlerKey string
+
+const (
+	textDeltaHandlerCtxKey textDeltaHandlerKey = "github.com/stellarlinkco/agentsdk-go/text-delta-handler"
+	// TextDeltaHandlerKey 供外部调用方将 TextDeltaHandler 存入 context。
+	TextDeltaHandlerKey = textDeltaHandlerCtxKey
+)
+
 // MiddlewareState is the minimal contract required for model providers to
 // surface request/response data to middleware consumers without depending on
 // the middleware package (which would cause an import cycle).

--- a/pkg/model/openai.go
+++ b/pkg/model/openai.go
@@ -155,14 +155,17 @@ func (m *openaiModel) CompleteStream(ctx context.Context, req Request, cb Stream
 
 				delta := choice.Delta
 
-				// Handle reasoning_content from thinking models
+				// 处理 thinking 模型的 reasoning_content 增量，以 IsReasoning 标记回调给上游
 				if raw := delta.RawJSON(); raw != "" {
 					var dp map[string]json.RawMessage
 					if err := json.Unmarshal([]byte(raw), &dp); err == nil {
 						if rc, ok := dp["reasoning_content"]; ok {
 							var s string
-							if json.Unmarshal(rc, &s) == nil {
+							if json.Unmarshal(rc, &s) == nil && s != "" {
 								accumulatedReasoning.WriteString(s)
+								if err := cb(StreamResult{Delta: s, IsReasoning: true}); err != nil {
+									return err
+								}
 							}
 						}
 					}


### PR DESCRIPTION

当前 agentsdk 的 middleware 只有四个粗粒度钩子——BeforeAgent、AfterAgent、BeforeTool、AfterTool。模型的流式文本输出在 runStreamCollection 内部被消费，只有最终组装的 *model.Response 才会到达 AfterAgent。这意味着消费端在 LLM
生成过程中无法观测文本增量，轮询或 SSE 等近实时 UI 无法实现。

本次 PR 新增一个可选的 StreamMiddleware 接口，middleware 在实现 Middleware 的同时可选择额外实现此接口。当模型通过
CompleteStream 流式输出文本增量时，每个 delta 都会被分发给链上所有实现了 StreamMiddleware 的 middleware。

**设计**

不在 Middleware 接口上直接加方法（会破坏所有已有实现），而是定义独立的可选接口：

```golang
// Middleware 保持不变
type Middleware interface {
    Name() string
    BeforeAgent(ctx context.Context, st *State) error
    BeforeTool(ctx context.Context, st *State) error
    AfterTool(ctx context.Context, st *State) error
    AfterAgent(ctx context.Context, st *State) error
}
```

```golang
// StreamMiddleware 可选实现
type StreamMiddleware interface {
    AgentTextDelta(ctx context.Context, st *State, delta string) error
}
```