### PR TITLE
fix(model): replace "." placeholder with zero-width space for empty C…

### DIFF
--- a/pkg/model/openai.go
+++ b/pkg/model/openai.go
@@ -382,14 +382,14 @@ func convertMessagesToOpenAI(msgs []Message, defaults ...string) []openai.ChatCo
 			}
 			content := msg.Content
 			if strings.TrimSpace(content) == "" {
-				content = "."
+				content = "\u200b"
 			}
 			result = append(result, openai.UserMessage(content))
 		}
 	}
 
 	if len(result) == 0 {
-		result = append(result, openai.UserMessage("."))
+		result = append(result, openai.UserMessage("\u200b"))
 	}
 
 	return result
@@ -415,7 +415,7 @@ func buildOpenAIUserContentParts(msg Message) []openai.ChatCompletionContentPart
 		}
 	}
 	if len(parts) == 0 {
-		parts = append(parts, openai.TextContentPart("."))
+		parts = append(parts, openai.TextContentPart("\u200b"))
 	}
 	return parts
 }
@@ -443,7 +443,7 @@ func buildOpenAIAssistantMessage(msg Message) openai.ChatCompletionMessageParamU
 	// Set content
 	content := msg.Content
 	if strings.TrimSpace(content) == "" {
-		content = "."
+		content = "\u200b"
 	}
 	assistantParam.Content = openai.ChatCompletionAssistantMessageParamContentUnion{
 		OfString: openai.String(content),


### PR DESCRIPTION
将 OpenAI 消息转换中空 Content 的占位符从显式 "." 改为零宽空格 。

## Why

OpenAI API 要求 content 字段非空，当 assistant 消息仅有 tool calls 而无文本时，原实现用 "." 占位。这会带来两个问题：

1. 前端展示：. 作为可见字符出现在 UI 中，尤其工具调用间隙会出现散落点号
2. 反馈循环：下轮请求把含 . 的消息喂回模型，模型可能学到并原样输出 .

零宽空格  是业界标准做法（Anthropic SDK 同样采用），既满足 API 非空要求，又不产生可见文本